### PR TITLE
Bugfix:  omitOn was referenced before it was assigned a value

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1556,8 +1556,8 @@ def _frame(subjects, input, frame, embeds, options):
         limit = 1
 
     omitOn = False
-    if hasattr(options, 'default') and hasattr(options['defualts'], 'omitDefaultOn'):
-        omitOn = options['defualts']['omitDefaultOn']
+    if hasattr(options, 'default') and hasattr(options['defaults'], 'omitDefaultOn'):
+        omitOn = options['defaults']['omitDefaultOn']
 
     # iterate over frames adding input matches to list
     values = []


### PR DESCRIPTION
omitOn was referenced before it was assigned a value (line 1637).    This fix follows the JSON-LD spec section 6.10.2 by assigning an initial value to omitOn (cleared; then overridden by options if any are provided).
