### PR TITLE
Bugfix:  when frame is a non-empty array, take context from frame[0]

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1427,7 +1427,7 @@ class Processor:
         elif isinstance(frame, list):
             # save first context in the array
             if len(frame) > 0 and '@context' in frame[0]:
-                ctx = copy.copy(frame['@context'])
+                ctx = copy.copy(frame[0]['@context'])
 
             # expand all elements in the array
             tmp = []


### PR DESCRIPTION
I also submitted a pull request to the js repo with a test case to cover this.
