### PR TITLE
Add "literal" on context

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1062,7 +1062,7 @@ class JsonLdProcessor:
         subject = '(?:' + iri + '|' + bnode + ')' + ws
         property = iri + ws
         object = '(?:' + iri + '|' + bnode + '|' + literal + ')' + wso
-        graph = '(?:\\.|(?:(?:' + iri + '|' + bnode + ')' + wso + '\\.))'
+        graph = '(?:\\.|(?:(?:' + iri + '|' + bnode + '|' + literal + ')' + wso + '\\.))'
 
         # full quad regex
         quad = r'^' + wso + subject + property + object + graph + wso + '$'


### PR DESCRIPTION
According to the nquad specification http://sw.deri.org/2008/07/n-quads/ context (or graph in your code) must have the following structure:

contextTriple    ::= subject ws+ predicate ws+ object ( ws+ context )? ws\* '.' ws*
context  ::= uriref | nodeID | literal

An example here:
http://pythex.org/?regex=%5E%5B%20%5Ct%5D*(%3F%3A(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E)%7C(_%3A(%3F%3A%5BA-Za-z%5D%5BA-Za-z0-9%5D*)))%5B%20%5Ct%5D%2B(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E)%5B%20%5Ct%5D%2B(%3F%3A(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E)%7C(_%3A(%3F%3A%5BA-Za-z%5D%5BA-Za-z0-9%5D*))%7C(%3F%3A%22(%5B%5E%22%5C%5C%5D*(%3F%3A%5C%5C.%5B%5E%22%5C%5C%5D*)*)%22(%3F%3A(%3F%3A%5C%5E%5C%5E(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E))%7C(%3F%3A%40(%5Ba-z%5D%2B(%3F%3A-%5Ba-z0-9%5D%2B)*)))%3F))%5B%20%5Ct%5D*(%3F%3A%5C.%7C(%3F%3A(%3F%3A(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E)%7C(_%3A(%3F%3A%5BA-Za-z%5D%5BA-Za-z0-9%5D*))%7C(%3F%3A%22(%5B%5E%22%5C%5C%5D*(%3F%3A%5C%5C.%5B%5E%22%5C%5C%5D*)*)%22(%3F%3A(%3F%3A%5C%5E%5C%5E(%3F%3A%3C(%5B%5E%3A%5D%2B%3A%5B%5E%3E%5D*)%3E))%7C(%3F%3A%40(%5Ba-z%5D%2B(%3F%3A-%5Ba-z0-9%5D%2B)*)))%3F))%5B%20%5Ct%5D*%5C.))%5B%20%5Ct%5D*%24&test_string=%3Chttp%3A%2F%2Fwww.w3.org%2FTR%2F2003%2FCR-owl-guide-20030818%2Fwine%23GaryFarrellMerlot%3E%20%3Chttp%3A%2F%2Fwww.w3.org%2FTR%2F2003%2FCR-owl-guide-20030818%2Fwine%23hasWineDescriptor%3E%20%3Chttp%3A%2F%2Fwww.w3.org%2FTR%2F2003%2FCR-owl-guide-20030818%2Fwine%23Dry%3E%20%22default-graph4294967295%22%20.&ignorecase=0&multiline=0&dotall=0&verbose=0
