### PR TITLE
build a key function directly instead of relying on cmp_to_key.

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -313,6 +313,9 @@ def remove_base(base, iri):
         return iri
 
     path = posixpath.normpath(posixpath.relpath(rel.path, base.path))
+    # workaround a relpath bug in Python 2.6 (http://bugs.python.org/issue5117)
+    if base.path == "/" and path.startswith("../"):
+        path = path[3:]
     if rel.path.endswith('/') and not path.endswith('/'):
         path += '/'
 


### PR DESCRIPTION
This approach is more direct, faster, and extends backwards compatibility from Python 2.7 to 2.6.
