### PR TITLE
Ensure that ActiveContextCache only enters a given combination of (activeCtx, localCtx) once in its internal FIFO

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -5089,7 +5089,12 @@ class ActiveContextCache(object):
             del self.cache[entry['activeCtx']][entry['localCtx']]
         key1 = json.dumps(active_ctx)
         key2 = json.dumps(local_ctx)
-        self.order.append({'activeCtx': key1, 'localCtx': key2})
+        # if we haven't seen this key combination before, add it to the deque.
+        # (if it already exists -- i.e., if we're overwriting an existing
+        # value -- then it's already contained in the deque, and we shouldn't
+        # do anything)
+        if key1 not in self.cache or key2 not in self.cache[key1]:
+            self.order.append({'activeCtx': key1, 'localCtx': key2})
         self.cache.setdefault(key1, {})[key2] = json.loads(json.dumps(result))
 
 


### PR DESCRIPTION
If `ActiveContextCache.set` is called multiple times during processing with a particular combination of `activeCtx` and `localCtx`, `ActiveContextCache.order` gets out of sync with `ActiveContextCache.cache` (i.e., multiple copies of a particular key combination can exist in `order` even though only one copy can be cached at any given time). This causes issues later in the cache's lifecycle when it begins to evict previously set elements. The first instance of a given (`activeCtx`, `localCtx`) found in `ActiveContextCache.order` will be evicted from `ActiveContextCache.cache` successfully, but subsequent copies will cause in a `KeyError`. To resolve this, I made inclusion in `ActiveContextCache.order` conditional on the (`activeCtx`, `localCtx`) combination not already existing in `ActiveContextCache.cache`. This keeps the two data structures are in sync and prevents the `KeyErrors`.