### PR TITLE
Support deflate encoding in load_document

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -388,7 +388,7 @@ def load_document(url):
             ('Accept', 'application/ld+json, application/json'),
             ('Accept-Encoding', 'deflate')]
         with closing(url_opener.open(url)) as handle:
-            content_encoding = handle.info().get('Content-Encoding', '') 
+            content_encoding = handle.info().get('Content-Encoding', '')
             if content_encoding == 'gzip':
                 buf = io.BytesIO(handle.read())
                 f = gzip.GzipFile(fileobj=buf, mode='rb')

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -83,7 +83,7 @@ else:
 
 __copyright__ = 'Copyright (c) 2011-2016 Digital Bazaar, Inc.'
 __license__ = 'New BSD license'
-__version__ = '0.7.1-dev'
+__version__ = '0.7.1'
 
 __all__ = [
     'compact', 'expand', 'flatten', 'frame', 'link', 'from_rdf', 'to_rdf',

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -14,6 +14,7 @@ JSON-LD.
 
 import copy
 import gzip
+import zlib
 import hashlib
 import io
 import json
@@ -387,10 +388,13 @@ def load_document(url):
             ('Accept', 'application/ld+json, application/json'),
             ('Accept-Encoding', 'deflate')]
         with closing(url_opener.open(url)) as handle:
-            if handle.info().get('Content-Encoding') == 'gzip':
+            content_encoding = handle.info().get('Content-Encoding', '') 
+            if content_encoding == 'gzip':
                 buf = io.BytesIO(handle.read())
                 f = gzip.GzipFile(fileobj=buf, mode='rb')
                 data = f.read()
+            elif content_encoding == 'deflate':
+                data = zlib.decompress(handle.read())
             else:
                 data = handle.read()
             doc = {

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -83,7 +83,7 @@ else:
 
 __copyright__ = 'Copyright (c) 2011-2016 Digital Bazaar, Inc.'
 __license__ = 'New BSD license'
-__version__ = '0.7.1'
+__version__ = '0.7.2-dev'
 
 __all__ = [
     'compact', 'expand', 'flatten', 'frame', 'link', 'from_rdf', 'to_rdf',


### PR DESCRIPTION
When attempting to load a document that returned Content-Encoding: deflate, a utf8 decode error exception was thrown.

This patch uses the zlib library to inflate the binary bytes before before decoding
```
Details: {'url': u'https://w3id.org/openbadges/legacy-v1'}
Cause: ('Could not retrieve a JSON-LD document from the URL.',)
Type: jsonld.LoadDocumentError
Code: loading document failed
Cause: 'utf8' codec can't decode byte 0x9c in position 1: invalid start byte  
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 399, in load_document
    'document': data.decode('utf8')
  File "xxxxx/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 4066, in _retrieve_context_urls
    remote_doc = load_document(url)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 425, in load_document
    cause=cause)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 1177, in process_context
    local_ctx, {}, options['documentLoader'], options['base'])
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 4105, in _retrieve_context_urls
    self._retrieve_context_urls(ctx, cycles_, load_document, url)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 4073, in _retrieve_context_urls
    code='loading remote context failed', cause=cause)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 683, in compact
    active_ctx = self.process_context(active_ctx, ctx, options)
  File "xxxxx/lib/python2.7/site-packages/pyld/jsonld.py", line 1181, in process_context
    'jsonld.ContextError', cause=cause)
```