### PR TITLE
Fix a KeyError in N-Quads normalization

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1614,7 +1614,7 @@ class JsonLdProcessor(object):
                 .replace('\"', '\\"'))
             quad += '"' + escaped + '"'
             if o['datatype'] == RDF_LANGSTRING:
-                if o['language']:
+                if o.get('language'):
                     quad += '@' + o['language']
             elif o['datatype'] != XSD_STRING:
                 quad += '^^<' + o['datatype'] + '>'


### PR DESCRIPTION
I wanted to try using this package with my new JSON-LD API, with URLs such as http://api.conceptnet.io/c/en/example .

It seems to be able to do simple transformations of the data, but it fails when I ask it to convert to N-Quads format:

```python
>>> from pyld import jsonld
>>> jsonld.to_rdf('http://api.conceptnet.io/c/en/example', options={'format': 'application/nquads'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/rspeer/.virtualenvs/lum/lib/python3.5/site-packages/pyld/jsonld.py", line 295, in to_rdf
    return JsonLdProcessor().to_rdf(input_, options)
  File "/home/rspeer/.virtualenvs/lum/lib/python3.5/site-packages/pyld/jsonld.py", line 1147, in to_rdf
    return self.to_nquads(dataset)
  File "/home/rspeer/.virtualenvs/lum/lib/python3.5/site-packages/pyld/jsonld.py", line 1562, in to_nquads
    quads.append(JsonLdProcessor.to_nquad(triple, graph_name))
  File "/home/rspeer/.virtualenvs/lum/lib/python3.5/site-packages/pyld/jsonld.py", line 1617, in to_nquad
    if o['language']:
KeyError: 'language'
```

Changing this to `o.get('language')` seems to fix the problem, so that's what this patch does.

This patch passes the tests in `normalization/tests`. It doesn't pass `json-ld.org/test-suite`, but it seems the master branch doesn't either.