### PR TITLE
Check if parent is @list, closes #54

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3316,8 +3316,6 @@ class JsonLdProcessor(object):
             except AttributeError:
                 ids = list(embeds.keys())
             for next in ids:
-                print next
-
                 if (next in embeds and
                         _is_object(embeds[next]['parent']) and
                         '@id' in embeds[next]['parent'] and # could be @list

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3316,8 +3316,11 @@ class JsonLdProcessor(object):
             except AttributeError:
                 ids = list(embeds.keys())
             for next in ids:
+                print next
+
                 if (next in embeds and
                         _is_object(embeds[next]['parent']) and
+                        '@id' in embeds[next]['parent'] and # could be @list
                         embeds[next]['parent']['@id'] == id_):
                     del embeds[next]
                     remove_dependents(next)


### PR DESCRIPTION

If the parent resource is an `@list`, it does not have `@id`, therefore line 3321 fails with the `KeyError`. This patch adds in a check that `@id` is indeed in the parent keys.

Closes #54, but it would be good to add the code from the issue as a test case.
