### PR TITLE
Always try to add a default @type and @language

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -4182,9 +4182,9 @@ class JsonLdProcessor(object):
                 else:
                     # add an entry for the default language
                     entry['@language'].setdefault(default_language, term)
-                    # add entries for no type and no language
-                    entry['@type'].setdefault('@none', term)
-                    entry['@language'].setdefault('@none', term)
+                # add entries for no type and no language
+                entry['@type'].setdefault('@none', term)
+                entry['@language'].setdefault('@none', term)
 
         return inverse
 


### PR DESCRIPTION
Fixes #59

In cases where @type was set, but not @language, one or the other would end up being an empty dictionary.

I have not run any tests on this, or added test cases, so that might need to be addressed before merging.