### PR TITLE
requests, paths, etc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ python:
   - "3.6"
   - "pypy3"
 sudo: false
-# no requirements, but simulate what a user would see
-install: pip install .
 # download test suite and run tests... submodule? meta testing project with
 # all of the reference implementations?
 script: 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   matches test suite behavior and other processing libs such as [jsonld.js][].
 - **BREAKING**: Fix path normalization to pass test suite RFC 3984 tests. This
   could change output for various relative URL edge cases.
+- Allow empty lists to be compacted to any @list container term. (Port from
+  [jsonld.js][])
 
 ### Changed
 - **BREAKING**: Remove older document loader code. SSL/SNI support wasn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,27 @@
   matches test suite behavior and other processing libs such as [jsonld.js][].
 - **BREAKING**: Fix path normalization to pass test suite RFC 3984 tests. This
   could change output for various relative URL edge cases.
-- Allow empty lists to be compacted to any @list container term. (Port from
+- Allow empty lists to be compacted to any `@list` container term. (Port from
   [jsonld.js][])
 
 ### Changed
 - **BREAKING**: Remove older document loader code. SSL/SNI support wasn't
   working well with newer Pythons.
-- **BREAKING**: Switch to [requests][] for document loading. Some behavior
+- **BREAKING**: Switch to [Requests][] for document loading. Some behavior
   could slightly change. Better supported in Python 2 and Python 3.
 
 ### Added
 - Support for test suite using http or https.
 - Easier to create a custom Requests document loader with the
-  `requests\_document\_loader` call. Adds a `secure` flag to always use HTTPS.
-  Can pass in keywords that [requests][] understands. `verify` to disable SSL
+  `requests_document_loader` call. Adds a `secure` flag to always use HTTPS.
+  Can pass in keywords that [Requests][] understands. `verify` to disable SSL
   verification or use custom cert bundles. `cert` to use client certs.
   `timeout` to fail on timeouts (important for production use!). See
-  [requests][] docs for more info.
+  [Requests][] docs for more info.
 
 ## Before 0.7.4
 
 - See git history for changes.
 
 [jsonld.js]: https://github.com/digitalbazaar/jsonld.js
-[requests]: http://docs.python-requests.org/
+[Requests]: http://docs.python-requests.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# pyld ChangeLog
+
+### Fixed
+- **BREAKING**: Default http (80) and https (443) ports removed from URLs. This
+  matches test suite behavior and other processing libs such as [jsonld.js][].
+- **BREAKING**: Fix path normalization to pass test suite RFC 3984 tests. This
+  could change output for various relative URL edge cases.
+
+### Changed
+- **BREAKING**: Remove older document loader code. SSL/SNI support wasn't
+  working well with newer Pythons.
+- **BREAKING**: Switch to [requests][] for document loading. Some behavior
+  could slightly change. Better supported in Python 2 and Python 3.
+
+### Added
+- Support for test suite using http or https.
+- Easier to create a custom Requests document loader with the
+  `requests\_document\_loader` call. Adds a `secure` flag to always use HTTPS.
+  Can pass in keywords that [requests][] understands. `verify` to disable SSL
+  verification or use custom cert bundles. `cert` to use client certs.
+  `timeout` to fail on timeouts (important for production use!). See
+  [requests][] docs for more info.
+
+## Before 0.7.4
+
+- See git history for changes.
+
+[jsonld.js]: https://github.com/digitalbazaar/jsonld.js
+[requests]: http://docs.python-requests.org/

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,18 @@ Quick Examples
     # normalized is a string that is a canonical representation of the document
     # that can be used for hashing, comparison, etc.
 
+Document Loader
+---------------
+
+The default document loader for PyLD uses Requests_. In a production
+environment you may want to setup a custom loader that, at a minimum, sets a
+timeout value. You can also force requests to use https, set client certs,
+disable verification, or set other Requests_ parameters.
+
+.. code-block:: Python
+
+    jsonld.set_document_loader(jsonld.requests_document_loader(timeout=...))
+
 Commercial Support
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Requirements
 ------------
 
 - Python_ (2.7 or later)
+- Requests_
 
 Installation
 ------------
@@ -157,6 +158,7 @@ Then run the test application using the directories containing the tests:
 .. _Microdata: http://www.w3.org/TR/microdata/
 .. _Microformats: http://microformats.org/
 .. _Python: http://www.python.org/
+.. _Requests: http://docs.python-requests.org/
 .. _RDFa: http://www.w3.org/TR/rdfa-core/
 .. _RFC7159: http://tools.ietf.org/html/rfc7159
 .. _pip: http://www.pip-installer.org/

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -13,20 +13,14 @@ JSON-LD.
 """
 
 import copy
-import gzip
 import hashlib
-import io
 import json
-import os
 import posixpath
 import re
 import requests
-import socket
-import ssl
 import string
 import sys
 import traceback
-import zlib
 from collections import deque, namedtuple
 from numbers import Integral, Real
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,7 @@ setup(
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries',
     ],
+    install_requires = [
+        'requests'
+    ],
 )


### PR DESCRIPTION
Looking for feedback on the doc loader API:
-  Should it more closely match the jsonld.js one?  (ie, a documentLoader.requests object or similar)
-  This one doesn't have to support web and servers but it's still a similar pattern that allows using custom loaders.  There might be a use case for changing things to support the old API vs requests lib.
- Is it worth the trouble to made 'requests' optional and provide a simpler (though maybe broken) loader like the old code?

The path futzing changes pass the tests now but it's unclear how correct or optimal it is.  I just moved closer to what jsonld.js does.