### PR TITLE
Fix: Provide jsonld.LoadDocumentError for the type of error in dummy_document_loader

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -370,6 +370,7 @@ def dummy_document_loader(**kwargs):
         :return: the RemoteDocument.
         """
         raise JsonLdError('No default document loader configured',
+                          'jsonld.LoadDocumentError',
                           {'url': url}, code='no default document loader')
 
     return loader


### PR DESCRIPTION
Addresses a part of #78 forbidding proper error msg to be displayed