### PR TITLE
Fix behavior to terminate generators

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -5499,7 +5499,7 @@ def permutations(elements):
 
         # no more permutations
         if k is None:
-            raise StopIteration
+            return
 
         # swap k and the element it is looking at
         swap = pos - 1 if left[k] else pos + 1


### PR DESCRIPTION
Many more tests fail when running the normalization test suite on Python
3.7 than on 2.7, 3.5, or 3.6.  The reason is PEP 479, which introduces a
change in behavior when raising StopIteration inside a generator.  The
new behavior is to silently turn this into a RuntimeError.

The PEP also states the way to deal with this, i.e.

    Finally, the proposal also clears up the confusion about how
    to terminate a generator: the proper way is return, not raise
    StopIteration.