### PR TITLE
Speed up of compare_values and has_value methods

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1148,24 +1148,31 @@ class JsonLdProcessor:
 
         :return: True if the value exists, False if not.
         """
+        # Localize the method lookup to avoids repeated class-attribute resolution in the loop/logic and increase performance
+        compare = JsonLdProcessor.compare_values
+
         if JsonLdProcessor.has_property(subject, property):
             val = subject[property]
+
+            # 1. Normalize @list objects
             # Avoid double checking if val is a list.
             # If val is a list, then we treat is as an array (i.e. if value occurs in the list, has_value returns true)
-            # TODO: is this desirable behavior?
             if _is_list(val):
                 val = val['@list']
 
+            # 2. Handle Collection (Array/List)
             if _is_array(val):
-                for v in val:
-                    # Avoid in depth comparison if the types are not the same
-                    if type(v) == type(value):
-                        return JsonLdProcessor.compare_values(value, v)
+                # 'any' with a localized function is the fastest way to loop in Python
+                return any(compare(value, v) for v in val)
+
+            # 3. Handle Single Value
             # avoid matching the set of values with an array value parameter
-            # TODO: this means that if `value` is an array, there will be no comparison at all and we default to False
-            # is this desirable behavior?
-            elif not _is_array(value) and type(val) == type(value):
-                return JsonLdProcessor.compare_values(value, val)
+            # TODO: If the parameter 'value' is an array, there will be no comparison at all if `value` is an array and 
+            # we default to False. Hence, has_value usually returns False unless comparing against another array
+            # (which is rare here). Is this desirable behavior?
+            if not _is_array(value):
+                return compare(value, val)
+
         return False
 
     @staticmethod


### PR DESCRIPTION
I noticed very slow performance on the `to_rdf` procedure for a JSON-LD file with several tens of thousands of typed object values for a single property.

Running cProfiles, it turned out that there was an inordinate amount of type spent in the methods `compare_values` and `has_value`.

This pull request introduces the following changes:
* Re-implemented `compare_values` with exception handling rather than if-then statements. Also changed the ordering and removed the boolean comparison between primitive values (It may need to return, but I couldn't understand the reason behind it)
* Re-implemented the `has_value` method (which called `compare_values` so very frequently) to perform checks only once, and only compare values of the same type.

There's also a question on the way the `has_value` is implemented: it seems that if the `value` parameter that's passed is an array, it is completely ignored. Is that the correct behavior?