### PR TITLE
Fix inverse context cache indexing to use the uuid field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 docs/_build
 lib/PyLD.egg-info
 profiler
+tests/test_caching.py
+tests/data/test_caching.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # pyld ChangeLog
 
+### Changed
+* Fix inverse context cache indexing to use the uuid field
+
 ## 2.0.1 - 2020-04-15
 
 ### Changed

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -5540,7 +5540,7 @@ class JsonLdProcessor(object):
         :return: the inverse context.
         """
         # inverse context already generated
-        inverse = _inverse_context_cache.get(id(active_ctx))
+        inverse = _inverse_context_cache.get(active_ctx['_uuid'])
         if inverse:
             return inverse
 
@@ -5613,7 +5613,7 @@ class JsonLdProcessor(object):
                     entry['@type'].setdefault('@none', term)
                     entry['@language'].setdefault('@none', term)
 
-        _inverse_context_cache[id(active_ctx)] = inverse
+        _inverse_context_cache[active_ctx['_uuid']] = inverse
         return inverse
 
     def _clone_active_context(self, active_ctx):


### PR DESCRIPTION
instead of the object id of the active context.

Fixes #119.

@Panaetius, please see if using this branch solves the problem for you.