### PR TITLE
Remove multiple header entries in call to requests.get()

### DIFF
--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -60,7 +60,8 @@ def requests_document_loader(secure=False, **kwargs):
                 headers = {
                     'Accept': 'application/ld+json, application/json'
                 }
-            response = requests.get(url, headers=headers, **kwargs)
+                kwargs['headers'] = headers
+            response = requests.get(url, **kwargs)
 
             content_type = response.headers.get('content-type')
             if not content_type:


### PR DESCRIPTION
This suggested fix adds headers to ```kwargs``` in ```documentloader.requests.loader()```. Feel free to not accept and close if there's a better way of doing this. AFAICT, mutating ```kwargs``` locally should be safe.

Fixes the problem described in issue #125 when supplying user-defined headers to ```jsonld.requests_document_loader```:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/pyld/documentloader/requests.py", line 64, in loader
    response = requests.get(url, headers=headers, **kwargs)
TypeError: get() got multiple values for keyword argument 'headers'
```

Closes #125 

