### PR TITLE
Issue 128

### DIFF
--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -12,8 +12,9 @@ Remote document loader using Requests.
 import string
 import re
 import urllib.parse as urllib_parse
+from json import JSONDecodeError
 
-from pyld.jsonld import (JsonLdError, parse_link_header, LINK_HEADER_REL)
+from pyld.jsonld import (JsonLdError, parse_link_header, prepend_base, LINK_HEADER_REL)
 
 
 def requests_document_loader(secure=False, max_link_follows=2, **kwargs):
@@ -70,7 +71,7 @@ def requests_document_loader(secure=False, max_link_follows=2, **kwargs):
             }
             try:
                 doc['document'] = response.json()
-            except json.JSONDecodeError as e:
+            except JSONDecodeError as e:
                 # document body is not parseable, continue to check link headers
                 pass
             # if content_type in headers['Accept']:
@@ -96,7 +97,7 @@ def requests_document_loader(secure=False, max_link_follows=2, **kwargs):
                         linked_alternate.get('type') == 'application/ld+json' and
                         not re.match(r'^application\/(\w*\+)?json$', content_type)):
                     doc['contentType'] = 'application/ld+json'
-                    doc['documentUrl'] = jsonld.prepend_base(url, linked_alternate['target'])
+                    doc['documentUrl'] = prepend_base(url, linked_alternate['target'])
                     if link_follow_count >= max_link_follows:
                         raise requests.TooManyRedirects(f"Exceeded maximum link header redirects ({max_link_follows})")
                     return loader(doc['documentUrl'], options=options, link_follow_count=link_follow_count + 1)

--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -69,11 +69,10 @@ def requests_document_loader(secure=False, max_link_follows=2, **kwargs):
                 'documentUrl': response.url,
                 'document': None
             }
-            try:
+            # Try loading the JSON if the content_type matches
+            # A failure here means the response body is not valid json
+            if re.match(r'^application\/(\w*\+)?json$', content_type):
                 doc['document'] = response.json()
-            except JSONDecodeError as e:
-                # document body is not parseable, continue to check link headers
-                pass
             # if content_type in headers['Accept']:
             #    doc['document'] = response.json()
             link_header = response.headers.get('link')

--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -10,40 +10,37 @@ Remote document loader using Requests.
 .. moduleauthor:: Olaf Conradi <olaf@conradi.org>
 """
 import string
+import re
 import urllib.parse as urllib_parse
 
 from pyld.jsonld import (JsonLdError, parse_link_header, LINK_HEADER_REL)
 
 
-def requests_document_loader(secure=False, **kwargs):
+def requests_document_loader(secure=False, max_link_follows=2, **kwargs):
     """
     Create a Requests document loader.
-
     Can be used to setup extra Requests args such as verify, cert, timeout,
     or others.
-
     :param secure: require all requests to use HTTPS (default: False).
+    :param max_link_follows: Maximum number of alternate link follows allowed.
     :param **kwargs: extra keyword args for Requests get() call.
-
     :return: the RemoteDocument loader function.
     """
     import requests
 
-    def loader(url, options={}):
+    def loader(url, options={}, link_follow_count=0):
         """
         Retrieves JSON-LD at the given URL.
-
         :param url: the URL to retrieve.
-
         :return: the RemoteDocument.
         """
         try:
             # validate URL
             pieces = urllib_parse.urlparse(url)
             if (not all([pieces.scheme, pieces.netloc]) or
-                pieces.scheme not in ['http', 'https'] or
-                set(pieces.netloc) > set(
-                    string.ascii_letters + string.digits + '-.:')):
+                    pieces.scheme not in ['http', 'https'] or
+                    set(pieces.netloc) > set(
+                        string.ascii_letters + string.digits + '-.:')):
                 raise JsonLdError(
                     'URL could not be dereferenced; only "http" and "https" '
                     'URLs are supported.',
@@ -69,23 +66,30 @@ def requests_document_loader(secure=False, **kwargs):
                 'contentType': content_type,
                 'contextUrl': None,
                 'documentUrl': response.url,
-                'document': response.json()
+                'document': None
             }
+            try:
+                doc['document'] = response.json()
+            except json.JSONDecodeError as e:
+                # document body is not parseable, continue to check link headers
+                pass
+            # if content_type in headers['Accept']:
+            #    doc['document'] = response.json()
             link_header = response.headers.get('link')
             if link_header:
                 linked_context = parse_link_header(link_header).get(
                     LINK_HEADER_REL)
                 # only 1 related link header permitted
                 if linked_context and content_type != 'application/ld+json':
-                  if isinstance(linked_context, list):
-                      raise JsonLdError(
-                          'URL could not be dereferenced, '
-                          'it has more than one '
-                          'associated HTTP Link Header.',
-                          'jsonld.LoadDocumentError',
-                          {'url': url},
-                          code='multiple context link headers')
-                  doc['contextUrl'] = linked_context['target']
+                    if isinstance(linked_context, list):
+                        raise JsonLdError(
+                            'URL could not be dereferenced, '
+                            'it has more than one '
+                            'associated HTTP Link Header.',
+                            'jsonld.LoadDocumentError',
+                            {'url': url},
+                            code='multiple context link headers')
+                    doc['contextUrl'] = linked_context['target']
                 linked_alternate = parse_link_header(link_header).get('alternate')
                 # if not JSON-LD, alternate may point there
                 if (linked_alternate and
@@ -93,6 +97,9 @@ def requests_document_loader(secure=False, **kwargs):
                         not re.match(r'^application\/(\w*\+)?json$', content_type)):
                     doc['contentType'] = 'application/ld+json'
                     doc['documentUrl'] = jsonld.prepend_base(url, linked_alternate['target'])
+                    if link_follow_count >= max_link_follows:
+                        raise requests.TooManyRedirects(f"Exceeded maximum link header redirects ({max_link_follows})")
+                    return loader(doc['documentUrl'], options=options, link_follow_count=link_follow_count + 1)
             return doc
         except JsonLdError as e:
             raise e


### PR DESCRIPTION
Addresses issue #128 for the requests document downloader. This adds an optional keyword parameter `max_link_follows` (defaults to 2) to `requests_document_loader` to avoid possible infinite recursion following link headers.