### PR TITLE
Treat invalid IRIs as errors in conversion to RDF

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3545,10 +3545,16 @@ class JsonLdProcessor(object):
                     continue
 
                 for item in items:
-                    # skip relative IRI subjects and predicates
+                    # All IDs should be absolute at this point in time
                     if not (_is_absolute_iri(id_) and
                             _is_absolute_iri(property)):
-                        continue
+                        raise JsonLdError(
+                            'JSON-LD graph conversion error; '
+                            'invalid IRI for property or ID, '
+                            'IRIs must be absolute',
+                            'jsonld.RdfError',
+                            {'@id': id_, 'property': property},
+                            code='invalid IRI')
 
                     # RDF subject
                     subject = {}


### PR DESCRIPTION
Currently invalid (i.e. non absolute) IRIs are ignored and tripples
containing non absolute IRIs are omitted from the RDF resulting from
`to_rdf`.

This patch changes this behaviour so that non absolute IRIs result in
exceptions instead.

See https://github.com/digitalbazaar/pyld/issues/137

I am not sure what to do about testing, it seems there are no general unit tests, but rather just some scaffolding to run the w3c tests (which fail).

If you want I can add some general unit tests for you, just need to agree on the framework I guess.