### PR TITLE
Clear out support for Python < 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - "3.4"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "pypy3"
 sudo: false
 
@@ -14,14 +13,6 @@ sudo: false
 env:
   - LOADER=requests
   - LOADER=aiohttp
-
-matrix:
-  exclude:
-    - python: "3.4"
-      env: LOADER=aiohttp
-  allow_failures:
-    - python: "3.4"
-    - python: "3.5"
 
 install:
   - pip install -r requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Requirements
 
 - Python_ (3.6 or later)
 - Requests_ (optional)
-- aiohttp_ (optional, Python 3.5 or later)
+- aiohttp_ (optional)
 
 Installation
 ------------

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3173,13 +3173,12 @@ class JsonLdProcessor(object):
                     ctx = import_ctx
                     ctx['_uuid'] = str(uuid.uuid1())
 
-                    # cache processed result (only Python >= 3.6)
+                    # cache processed result
                     # Note: this could potenially conflict if the import
                     # were used in the same active context as a referenced
                     # context and an import. In this case, we
                     # could override the cached result, but seems unlikely.
-                    if sys.version_info[0] > 3 or sys.version_info[1] >= 6:
-                        resolved_import.set_processed(active_ctx, freeze(ctx))
+                    resolved_import.set_processed(active_ctx, freeze(ctx))
 
                 defined['@import'] = True
 
@@ -3313,11 +3312,10 @@ class JsonLdProcessor(object):
                                 'jsonld.SyntaxError', {'context': key_ctx, 'term': k},
                                 code='invalid scoped context')
 
-            # cache processed result (only Python >= 3.6)
+            # cache processed result
             # and give the context a unique identifier
             rval = freeze(rval)
-            if sys.version_info[0] > 3 or sys.version_info[1] >= 6:
-                resolved_context.set_processed(active_ctx, rval)
+            resolved_context.set_processed(active_ctx, rval)
 
         return rval
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-aiohttp; python_version >= '3.5'
+aiohttp
 lxml
 cachetools
 frozendict

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -424,10 +424,7 @@ def read_json(filename):
 
 def read_file(filename):
     with open(filename) as f:
-        if sys.version_info[0] >= 3:
-            return f.read()
-        else:
-            return f.read().decode('utf8')
+        return f.read()
 
 
 def read_test_url(property):


### PR DESCRIPTION
The README already documented the project needs Python >= 3.6, so I removed code related to Python 2.7, 3.4, and 3.5.

Note that the removed `if sys.version_info[0] > 3 or sys.version_info[1] >= 6:` was strange, as it accepted Python 2.6.

Oh I added 3.9 to travis, hope travis already supports it and it's OK to add to the project: 3.9 has been released a few days ago.