### PR TITLE
frozendict → immutabledict (as frozendict is unmaintained)

### DIFF
--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -8,7 +8,7 @@ Context Resolver for managing remote contexts.
 .. moduleauthor:: Gregg Kellogg <gregg@greggkellogg.net>
 """
 
-from frozendict import frozendict
+from immutabledict import immutabledict
 from c14n.Canonicalize import canonicalize
 from pyld import jsonld
 from .resolved_context import ResolvedContext
@@ -42,7 +42,7 @@ class ContextResolver:
             cycles = set()
 
         # process `@context`
-        if (isinstance(context, dict) or isinstance(context, frozendict)) and '@context' in context:
+        if (isinstance(context, dict) or isinstance(context, immutabledict)) and '@context' in context:
             context = context['@context']
 
         # context is one or more contexts
@@ -65,7 +65,7 @@ class ContextResolver:
                     all_resolved.append(resolved)
             elif not ctx:
                 all_resolved.append(ResolvedContext(False))
-            elif not isinstance(ctx, dict) and not isinstance(ctx, frozendict):
+            elif not isinstance(ctx, dict) and not isinstance(ctx, immutabledict):
                 raise jsonld.JsonLdError(
                     'Invalid JSON-LD syntax; @context must be an object.',
                     'jsonld.SyntaxError', {'context': ctx},
@@ -157,7 +157,7 @@ class ContextResolver:
                 code='loading remote context failed')
 
         # ensure ctx is an object
-        if not isinstance(context, dict) and not isinstance(context, frozendict):
+        if not isinstance(context, dict) and not isinstance(context, immutabledict):
             raise jsonld.JsonLdError(
                 'Dereferencing a URL did not result in a JSON object. The ' +
                 'response was valid JSON, but it was not a JSON object.',
@@ -188,7 +188,7 @@ class ContextResolver:
         :param context: the context.
         :param base: the base IRI to use to resolve relative IRIs.
         """
-        if not isinstance(context, dict) and not isinstance(context, frozendict):
+        if not isinstance(context, dict) and not isinstance(context, immutabledict):
             return
 
         ctx = context.get('@context')
@@ -201,11 +201,11 @@ class ContextResolver:
             for num, element in enumerate(ctx):
                 if isinstance(element, str):
                     ctx[num] = jsonld.prepend_base(base, element)
-                elif isinstance(element, dict) or isinstance(element, frozendict):
+                elif isinstance(element, dict) or isinstance(element, immutabledict):
                     self. _resolve_context_urls({'@context': element}, base)
             return
 
-        if not isinstance(ctx, dict) and not isinstance(ctx, frozendict):
+        if not isinstance(ctx, dict) and not isinstance(ctx, immutabledict):
             # no @context URLs can be found in non-object
             return
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -29,7 +29,7 @@ from collections import namedtuple
 from functools import cmp_to_key
 import lxml.html
 from numbers import Integral, Real
-from frozendict import frozendict
+from immutabledict import immutabledict
 from pyld.__about__ import (__copyright__, __license__, __version__)
 
 def cmp(a, b):
@@ -6295,7 +6295,7 @@ def _is_object(v):
 
     :return: True if the value is an Object, False if not.
     """
-    return isinstance(v, dict) or isinstance(v, frozendict)
+    return isinstance(v, dict) or isinstance(v, immutabledict)
 
 
 def _is_empty_object(v):
@@ -6539,7 +6539,7 @@ def _is_relative_iri(v):
 
 def freeze(value):
     if isinstance(value, dict):
-        return frozendict(dict([(k, v) for (k, v) in value.items()]))
+        return immutabledict(dict([(k, v) for (k, v) in value.items()]))
     return value
 
 # The default JSON-LD document loader.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests
 aiohttp; python_version >= '3.5'
 lxml
 cachetools
-frozendict
+immutabledict

--- a/setup.py
+++ b/setup.py
@@ -49,13 +49,13 @@ setup(
     ],
     install_requires=[
         'cachetools',
-        'frozendict',
+        'immutabledict',
         'lxml',
     ],
     extras_require={
         'requests': ['requests'],
         'aiohttp': ['aiohttp'],
         'cachetools': ['cachetools'],
-        'frozendict': ['frozendict'],
+        'immutabledict': ['immutabledict'],
     }
 )


### PR DESCRIPTION
This fixes the following warning:

    DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

from the [unmaintained](https://github.com/slezica/python-frozendict/issues/25) frozendict dependency.