### PR TITLE
Always follow link header if content-type is not json.

### DIFF
--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -10,9 +10,10 @@ Remote document loader using Requests.
 .. moduleauthor:: Olaf Conradi <olaf@conradi.org>
 """
 import string
+import re
 import urllib.parse as urllib_parse
 
-from pyld.jsonld import (JsonLdError, parse_link_header, LINK_HEADER_REL)
+from pyld.jsonld import (JsonLdError, parse_link_header, LINK_HEADER_REL, prepend_base)
 
 
 def requests_document_loader(secure=False, **kwargs):
@@ -69,7 +70,6 @@ def requests_document_loader(secure=False, **kwargs):
                 'contentType': content_type,
                 'contextUrl': None,
                 'documentUrl': response.url,
-                'document': response.json()
             }
             link_header = response.headers.get('link')
             if link_header:
@@ -77,22 +77,24 @@ def requests_document_loader(secure=False, **kwargs):
                     LINK_HEADER_REL)
                 # only 1 related link header permitted
                 if linked_context and content_type != 'application/ld+json':
-                  if isinstance(linked_context, list):
-                      raise JsonLdError(
-                          'URL could not be dereferenced, '
-                          'it has more than one '
-                          'associated HTTP Link Header.',
-                          'jsonld.LoadDocumentError',
-                          {'url': url},
-                          code='multiple context link headers')
-                  doc['contextUrl'] = linked_context['target']
+                    if isinstance(linked_context, list):
+                        raise JsonLdError(
+                            "URL could not be dereferenced, "
+                            "it has more than one "
+                            "associated HTTP Link Header.",
+                            "jsonld.LoadDocumentError",
+                            {"url": url},
+                            code="multiple context link headers")
+                    doc["contextUrl"] = linked_context["target"]
                 linked_alternate = parse_link_header(link_header).get('alternate')
                 # if not JSON-LD, alternate may point there
                 if (linked_alternate and
                         linked_alternate.get('type') == 'application/ld+json' and
                         not re.match(r'^application\/(\w*\+)?json$', content_type)):
                     doc['contentType'] = 'application/ld+json'
-                    doc['documentUrl'] = jsonld.prepend_base(url, linked_alternate['target'])
+                    doc['documentUrl'] = prepend_base(url, linked_alternate['target'])
+                    return loader(doc['documentUrl'], options=options)
+            doc["document"] = response.json()
             return doc
         except JsonLdError as e:
             raise e


### PR DESCRIPTION
Trying myself at https://github.com/digitalbazaar/pyld/pull/129#issuecomment-706078894

Fixes #128 
Ref https://github.com/digitalbazaar/pyld/pull/129

Highly inspired from #129, but trying myself at it.

Master before and after this PR has the same set of failing tests:
```
FAILED (failures=5, errors=2, skipped=30)
OK (skipped=1)
OK (skipped=3)
```

The tests provided in #129 are passing, and:

```python
print(
    json.dumps(
        jsonld.expand(
            {
                "@context": "http://schema.org/",
                "@type": "Person",
                "name": "Jane Doe",
                "jobTitle": "Professor",
                "telephone": "(425) 123-4567",
                "url": "http://www.janedoe.com",
            }
        ),
        indent=4,
    )
)
```

now passes too.