### PR TITLE
load_document: Lower priority of HTML inputs

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -6334,11 +6334,18 @@ def load_document(url,
 
     :return: True if the value is an absolute IRI, False if not.
     """
+    # Prefer JSON-LD and JSON (q=0.8) over HTML (q=0.5) to ensure proper
+    # content negotiation with servers that serve both formats at the same URL,
+    # such as https://www.w3.org/ns/activitystreams
+    # See: https://github.com/digitalbazaar/pyld/pull/170
     headers = {
-        'Accept': 'application/ld+json, application/json;q=0.8'
+        'Accept': (
+            'application/ld+json, '
+            'application/json;q=0.8, '
+            'text/html;q=0.5, '
+            'application/xhtml+xml;q=0.5'
+        )
     }
-    # FIXME: only if html5lib loaded?
-    headers['Accept'] = headers['Accept'] + ', text/html;q=0.5, application/xhtml+xml;q=0.5'
 
     if requestProfile:
         headers['Accept'] = ('application/ld+json;profile=%s, ' % requestProfile) + headers['Accept']

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -6335,10 +6335,10 @@ def load_document(url,
     :return: True if the value is an absolute IRI, False if not.
     """
     headers = {
-        'Accept': 'application/ld+json, application/json;q=0.5'
+        'Accept': 'application/ld+json, application/json;q=0.8'
     }
     # FIXME: only if html5lib loaded?
-    headers['Accept'] = headers['Accept'] + ', text/html;q=0.8, application/xhtml+xml;q=0.8'
+    headers['Accept'] = headers['Accept'] + ', text/html;q=0.5, application/xhtml+xml;q=0.5'
 
     if requestProfile:
         headers['Accept'] = ('application/ld+json;profile=%s, ' % requestProfile) + headers['Accept']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,11 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    # Register custom markers
+    config.addinivalue_line(
+        "markers", "network: marks tests as requiring network access (may be slow)"
+    )
+
     # Apply loader choice and selected test number globally so that the
     # existing `runtests` helpers behave the same as the CLI runner.
     loader = config.getoption('loader')

--- a/tests/test_document_loader.py
+++ b/tests/test_document_loader.py
@@ -1,0 +1,30 @@
+"""
+Tests for load_document function, specifically Accept header content negotiation.
+
+See: https://github.com/digitalbazaar/pyld/pull/170
+"""
+import pytest
+from pyld import jsonld
+
+
+@pytest.mark.network
+def test_activitystreams_context_loads_as_json():
+    """
+    The ActivityStreams context URL should return JSON-LD, not the HTML spec.
+    
+    This was the original bug report for PR #170.
+    
+    This test requires network access and may be slow or flaky.
+    """
+    options = {
+        'documentLoader': jsonld.requests_document_loader()
+    }
+    
+    result = jsonld.load_document(
+        'https://www.w3.org/ns/activitystreams',
+        options
+    )
+    
+    # Should be JSON-LD context, not HTML spec
+    assert isinstance(result['document'], dict)
+    assert '@context' in result['document']


### PR DESCRIPTION
This fixes a bug with activitypub related documents: The schema "https://www.w3.org/ns/activitystreams" renders the spec if "application/json" has a lower prioritisation than "text/html".