### PR TITLE
Added basic thread locks

### DIFF
--- a/lib/pyld/resolved_context.py
+++ b/lib/pyld/resolved_context.py
@@ -9,13 +9,16 @@ Representation for a resolved Context.
 """
 
 from cachetools import LRUCache
+import threading
 
 MAX_ACTIVE_CONTEXTS = 10
+
 
 class ResolvedContext:
     """
     A cached contex document, with a cache indexed by referencing active context.
     """
+
     def __init__(self, document):
         """
         Creates a ResolvedContext with caching for processed contexts
@@ -24,15 +27,18 @@ class ResolvedContext:
         # processor-specific RDF parsers
         self.document = document
         self.cache = LRUCache(maxsize=MAX_ACTIVE_CONTEXTS)
+        self.lock = threading.Lock()
 
     def get_processed(self, active_ctx):
         """
         Returns any processed context for this resolved context relative to an active context.
         """
-        return self.cache.get(active_ctx['_uuid'])
+        with self.lock:
+            return self.cache.get(active_ctx["_uuid"])
 
     def set_processed(self, active_ctx, processed_ctx):
         """
         Sets any processed context for this resolved context relative to an active context.
         """
-        self.cache[active_ctx['_uuid']] = processed_ctx
+        with self.lock:
+            self.cache[active_ctx["_uuid"]] = processed_ctx


### PR DESCRIPTION
The use of LRUCache has been problematic when run from multithreaded services. It doesn't take much, but a simple thread lock added will fix collisions between threads.