### PR TITLE
Allow passing custom headers and session into requests_document_loader

### DIFF
--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -55,11 +55,10 @@ def requests_document_loader(secure=False, **kwargs):
                     'the URL\'s scheme is not "https".',
                     'jsonld.InvalidUrl', {'url': url},
                     code='loading document failed')
-            headers = options.get('headers')
-            if headers is None:
-                headers = {
-                    'Accept': 'application/ld+json, application/json'
-                }
+            headers = {
+                'Accept': 'application/ld+json, application/json'
+            }
+            headers.update(options.get('headers', {}))
             response = requests.get(url, headers=headers, **kwargs)
 
             content_type = response.headers.get('content-type')

--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -64,6 +64,9 @@ def requests_document_loader(secure=False, **kwargs):
                 headers.update(kwargs['headers'])
                 del kwargs['headers']
             session = options.get('session', requests)
+            if 'session' in kwargs:
+                session = kwargs['session']
+                del kwargs['session']
             response = session.get(url, headers=headers, **kwargs)
 
             content_type = response.headers.get('content-type')

--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -60,6 +60,9 @@ def requests_document_loader(secure=False, **kwargs):
                 'Accept': 'application/ld+json, application/json'
             }
             headers.update(options.get('headers', {}))
+            if 'headers' in kwargs:
+                headers.update(kwargs['headers'])
+                del kwargs['headers']
             session = options.get('session', requests)
             response = session.get(url, headers=headers, **kwargs)
 


### PR DESCRIPTION
Sample usage:
`jsonld.set_document_loader(
    jsonld.requests_document_loader(
        timeout=Config.TIMEOUT,
        session=session,
        headers={"Accept": accept},
    )
)`