### PR TITLE
change 2 if statements

### DIFF
--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -63,7 +63,7 @@ class ContextResolver:
                     all_resolved.extend(resolved)
                 else:
                     all_resolved.append(resolved)
-            elif not ctx:
+            elif ctx is None:
                 all_resolved.append(ResolvedContext(False))
             elif not isinstance(ctx, dict) and not isinstance(ctx, frozendict):
                 raise jsonld.JsonLdError(

--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -63,7 +63,7 @@ class ContextResolver:
                     all_resolved.extend(resolved)
                 else:
                     all_resolved.append(resolved)
-            elif ctx is None:
+            elif ctx is None or ctx is False:
                 all_resolved.append(ResolvedContext(False))
             elif not isinstance(ctx, dict) and not isinstance(ctx, frozendict):
                 raise jsonld.JsonLdError(

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -2320,7 +2320,7 @@ class JsonLdProcessor(object):
                 for type_ in sorted(types):
                     ctx = JsonLdProcessor.get_context_value(
                         type_scoped_ctx, type_, '@context')
-                    if ctx:
+                    if ctx is not None and ctx is not False:
                         active_ctx = self._process_context(
                             active_ctx, ctx, options, propagate=False)
 
@@ -3070,7 +3070,7 @@ class JsonLdProcessor(object):
                 active_ctx['_uuid'] = str(uuid.uuid1())
 
             # reset to initial context
-            if ctx is None:
+            if ctx is None or ctx is False:
                 if (not override_protected and
                      any(v.get('protected') for v in rval['mappings'].values())):
                     raise JsonLdError(

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -2320,7 +2320,7 @@ class JsonLdProcessor(object):
                 for type_ in sorted(types):
                     ctx = JsonLdProcessor.get_context_value(
                         type_scoped_ctx, type_, '@context')
-                    if ctx is not None:
+                    if ctx:
                         active_ctx = self._process_context(
                             active_ctx, ctx, options, propagate=False)
 
@@ -3070,7 +3070,7 @@ class JsonLdProcessor(object):
                 active_ctx['_uuid'] = str(uuid.uuid1())
 
             # reset to initial context
-            if not ctx:
+            if ctx is None:
                 if (not override_protected and
                      any(v.get('protected') for v in rval['mappings'].values())):
                     raise JsonLdError(


### PR DESCRIPTION
This is to address #188

I believe there were 2 erroneous checks in the code. 

The first one was checking the statement `if not value`. In python logic, an empty object would count as a non-value, therefore we need to specifically check for None. This should be raised only if the value is explicitly declared as `null`, not if its an empty object, as described in the [json-ld-api expansion algorythm](https://w3c.github.io/json-ld-api/#overview-3).

The second wrong check has to do with the value False being returned and the code checking if the value is not None. False won't fall into this category, therefore we should check if there is a value instead.

Are any test-suites available to validate these changes? It has resolved my issue and I was able to successfully expand the traceability context.

Special thanks to [@dbluhm](https://github.com/dbluhm) for helping to narrow down this issue.

@dlongley @msporny we would like to request a new release of the `pyld` package with these bug fixes since aca-py currently relies on it for credential verification.