### PR TITLE
#181 Set up Dependabot to auto update submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # Update specifications' submodules
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+  - package-ecosystem: "submodules"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot will weekly check if new commits arrived in the specs' repositories. If yes, it will create a PR, which will run the tests.