### PR TITLE
Add testcase to confirm current link behaviour and add check if 'link' in options is instance of dict.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - An empty property-scoped context no longer resets the active context in `_create_term_definition`. Now only explicit null becomes False; empty contexts are preserved. Fixes [compact#tc028](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tc028), [toRdf#tc036](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tc036) and [expand#tc036](https://w3c.github.io/json-ld-api/tests/expand-manifest.html#tc036).
 - Options from the test manifest now override the options configured in `create_test_options()`, instead of the other way around. This fixes tests not able to override default options in the test-setup such as `extractAllScripts`. Fixes [html#tf004](https://w3c.github.io/json-ld-api/tests/html-manifest#tf004).
 - When `@type` is `@json` in a frame, it no longer raises an "Invalid JSON-LD syntax" error. Fixes [frame#t0069](https://w3c.github.io/json-ld-framing/tests/frame-manifest.html#t0069).
+- Use safeguard for non-dict values of `options['link']`
 
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1496,7 +1496,8 @@ class JsonLdProcessor:
         # recursively compact object
         if _is_object(element):
             if (
-                options['link']
+                isinstance(options['link'], dict)
+                and options['link']
                 and '@id' in element
                 and element['@id'] in options['link']
             ):
@@ -1511,7 +1512,7 @@ class JsonLdProcessor:
                 rval = self._compact_value(
                     active_ctx, active_property, element, options
                 )
-                if options['link'] and _is_subject_reference(element):
+                if isinstance(options['link'], dict) and options['link'] and _is_subject_reference(element):
                     # store linked element
                     options['link'].setdefault(element['@id'], []).append(
                         {'expanded': element, 'compacted': rval}
@@ -1556,7 +1557,11 @@ class JsonLdProcessor:
                     override_protected=True,
                 )
 
-            if options['link'] and '@id' in element:
+            if (
+                isinstance(options['link'], dict)
+                and options['link']
+                and '@id' in element
+            ):
                 # store linked element
                 options['link'].setdefault(element['@id'], []).append(
                     {'expanded': element, 'compacted': rval}

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -711,7 +711,7 @@ class TestFrame:
 
         # this should result in a RuntimeError for exceeding recursion depth
         frame = {'@context': 'http://schema.org', '@embed': '@link'}
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(RecursionError):
             jsonld.frame(input, frame)
 
 

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -655,7 +655,7 @@ class TestFrame:
         assert framed == expected
 
     def test_circular_references_link_and_embed(self):
-        j = {
+        input = {
             "@context": "http://schema.org/",
             "@type": "Person",
             "name": "Jane Doe",
@@ -670,12 +670,49 @@ class TestFrame:
             },
         }
 
-        frame = {'@context': 'http://schema.org', '@embed': '@last'}
-        jsonld.frame(j, frame)
+        expected = {
+            "@context": "http://schema.org",
+            "@graph": [
+                {
+                "id": "http://www.janedoe.com",
+                "type": "Person",
+                "jobTitle": "Professor",
+                "knows": {
+                    "id": "http://www.johnsmith.me",
+                    "type": "Person",
+                    "knows": {
+                    "id": "http://www.janedoe.com"
+                    },
+                    "name": "John Smith"
+                },
+                "name": "Jane Doe",
+                "telephone": "(425) 123-4567"
+                },
+                {
+                "id": "http://www.johnsmith.me",
+                "type": "Person",
+                "knows": {
+                    "id": "http://www.janedoe.com",
+                    "type": "Person",
+                    "jobTitle": "Professor",
+                    "knows": {
+                    "id": "http://www.johnsmith.me"
+                    },
+                    "name": "Jane Doe",
+                    "telephone": "(425) 123-4567"
+                },
+                "name": "John Smith"
+                }
+            ]
+        }
 
-        # this should not result in a RuntimeError for exceeding recursion depth
-        frame['@embed'] = '@link'
-        jsonld.frame(j, frame)
+        frame = {'@context': 'http://schema.org', '@embed': '@once'}
+        assert expected == jsonld.frame(input, frame)
+
+        # this should result in a RuntimeError for exceeding recursion depth
+        frame = {'@context': 'http://schema.org', '@embed': '@link'}
+        with pytest.raises(Exception) as e_info:
+            jsonld.frame(input, frame)
 
 
 class TestToRdf:

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -654,6 +654,29 @@ class TestFrame:
         framed = jsonld.frame(input, frame)
         assert framed == expected
 
+    def test_circular_references_link_and_embed(self):
+        j = {
+            "@context": "http://schema.org/",
+            "@type": "Person",
+            "name": "Jane Doe",
+            "jobTitle": "Professor",
+            "telephone": "(425) 123-4567",
+            "@id": "http://www.janedoe.com",
+            "knows": {
+                "name": "John Smith",
+                "@type": "Person",
+                "@id": "http://www.johnsmith.me",
+                "knows": {"@id": "http://www.janedoe.com"},
+            },
+        }
+
+        frame = {'@context': 'http://schema.org', '@embed': '@last'}
+        jsonld.frame(j, frame)
+
+        # this should not result in a RuntimeError for exceeding recursion depth
+        frame['@embed'] = '@link'
+        jsonld.frame(j, frame)
+
 
 class TestToRdf:
     # PR: https://github.com/digitalbazaar/pyld/pull/202


### PR DESCRIPTION
This PR adds a testcase for link that confirms the current behaviour and adds a safeguard for non-dict values of `options['link']` where applicable. An empty dict is not truthy in python, so cannot just check for "if options['link']". However, this in some places, this is desired.

Fixes https://github.com/digitalbazaar/pyld/issues/64
Replaces #66 because it was too outdated for a merge. 

