### PR TITLE
Minor fixes to nquads handling

### DIFF
--- a/lib/pyld/nquads.py
+++ b/lib/pyld/nquads.py
@@ -192,7 +192,7 @@ def serialize_nquad(triple, graph_name=None):
         escaped = escape(o['value'])
         quad += '"' + escaped + '"'
         if o['datatype'] == RDF_LANGSTRING:
-            if o['language']:
+            if o.get('language'):
                 quad += '@' + o['language']
         elif o['datatype'] != XSD_STRING:
             quad += '^^<' + o['datatype'] + '>'

--- a/lib/pyld/nquads.py
+++ b/lib/pyld/nquads.py
@@ -15,7 +15,7 @@ def parse_nquads(input_):
     """
     # define partial regexes
     iri = '(?:<([^:]+:[^>]*)>)'
-    bnode = '(_:(?:[A-Za-z][A-Za-z0-9]*))'
+    bnode = '(_:(?:[A-Za-z0-9_][A-Za-z0-9_.-]*))'
     plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"'
     datatype = '(?:\\^\\^' + iri + ')'
     language = '(?:@([a-zA-Z]+(?:-[a-zA-Z0-9]+)*))'

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1046,7 +1046,6 @@ TEST_TYPES = {
         },
         'skip': {
             'idRegex': [
-                '.*manifest-urdna2015#test059$',
                 '.*manifest-urdna2015#test060$',
             ]
         },


### PR DESCRIPTION
This PR does minor fixes to the nquad parsings/serialization, including
- improving the regex for extracting bnodes (this makes urdna2015#test059 pass)
- using stdlib line splitting instead of custom regex
- isolating escaping and unescaping literal values for fixing encoding and escaping issues later on (~ urdna2015#test060$)
- fix a KeyError in N-Quads serialization (see https://github.com/digitalbazaar/pyld/pull/52)

(Sidenote about escaping and urdna2015#test060: this is a very tricky one - believe me, I tried-  and I think this whole file should eventually be replaced by RDFLib instead of pursuing this)
