### PR TITLE
Implement RDFC-1.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,6 +69,7 @@ jobs:
         pytest tests/test_manifests.py --tests=./specifications/json-ld-api/tests --loader=${{ matrix.loader }}
         pytest tests/test_manifests.py --tests=./specifications/json-ld-framing/tests --loader=${{ matrix.loader }}
         pytest tests/test_manifests.py --tests=./specifications/normalization/tests --loader=${{ matrix.loader }}
+        pytest tests/test_manifests.py --tests=./specifications/rdf-canon/tests --loader=${{ matrix.loader }}
         pytest --ignore ./tests/test_manifests.py
       env:
         LOADER: ${{ matrix.loader }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "specifications/normalization"]
 	path = specifications/normalization
 	url = https://github.com/json-ld/normalization.git
+[submodule "specifications/rdf-canon"]
+	path = specifications/rdf-canon
+	url = https://github.com/w3c/rdf-canon.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Numbers with 0 as fractional part now parse to an `xsd:integer` instead of `xsd:double`. Fixes [toRdf#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02).
 - Zeros are now truncated for numeric values with negative exponent.
 - Blank node prefixes are now also used in IRI expansion.
+- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double
 
 ## 3.1.0 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # pyld ChangeLog
 
+## 4.0.0 - unreleased
+
+### Added
+
+- migrate `canon.py` to `rdflib`
+  - added `rdflib` dependency in all relevant config and code files.
+  - added `util.py`:
+    - added the functions `from_legacy_dataset()` and `to_legacy_dataset()` to convert an `rdflib.Dataset` to an RDFJS-like `dict` and back wherever needed. 
+    - added unittests in `tests/test_util.py` for these functions.
+- implement RDFC1.0
+  - added new class `RDFC10` (subclass of `URDNA2015`) in `canon.py`
+  - added the RDFC1.0 test-suite in `tests/runtests.py`
+    - added support for testing blank-node identifier maps. 
+    - added support for testing with different hashing algorithms
+
+### Changed
+  - migrate `canon.py` to `rdflib`:
+    - now use `rdflib` for RDF term type checking (e.g., checking is something is a bnode), looping over triples/quads, nquads serialization and constructing RDF terms  (custom deepcopy is no longer needed) 
+    - move nquads parsing from`JsonLdProcessor.normalize()` to `URDNA2015.main()` so all parsing and serialization is handled by the same class. 
+    - move the main logic to `URDNA2015._canonicalize(self, dataset: Dataset)` while keeping input and output in `URDNA2015.main()`. The method `URDNA2015._canonicalize(self, dataset: Dataset)` accepts an `rdflib.Dataset` and returns a tuple with 
+        - the canonicalized result as a nquads `str` and 
+        - the blank node identifier map as `dict`.
+    - the method `URDNA2015 .main(self, dataset: str | dict | Dataset, options)` now 
+      - accepts a `rdflib.Dataset` object in addition to an nquads `str` or the original RDFJS-like`dict`. 
+      - returns 
+        - a `str`: the serialized nquads result, or 
+        - a `dict`: the result as RDFJS-like dataset or the blank node identifier map when the new parameter `outputMap` is `True`.
+    - the hashing algorithm is now an class attribute `URDNA2015.hash_algorithm` so it  configurable (required for RDFC1.0)
+    - the `permutations()` function now uses `itertools.permutations` instead of a custom implementation.
+    - replacements for rdflib's `_nq_row` and `_quoteLiteral` (these should eventually move to a fix for rdflib's nquads serializer).
+  - (re-)enabled all skipped URDNA2015, URDNA2012 tests in `tests/runtests.py`
+  - if the result of a test is a dict and the expected value is a string, the expected value is now parsed as JSON (needed for testing blank-node identifier maps).
+
 ## 3.2.0 - unreleased
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Numbers with 0 as fractional part now parse to an `xsd:integer` instead of `xsd:double`. Fixes [toRdf#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02).
 - Zeros are now truncated for numeric values with negative exponent.
 - Blank node prefixes are now also used in IRI expansion.
-- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double
+- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double in json-ld-1.1 processing mode.
 
 ## 3.1.0 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # pyld ChangeLog
 
+## 4.0.0 - unreleased
+
+### Added
+
+- migrate `canon.py` to `rdflib`
+  - added `rdflib` dependency in all relevant config and code files.
+  - added `util.py`:
+    - added the functions `from_legacy_dataset()` and `to_legacy_dataset()` to convert an `rdflib.Dataset` to an RDFJS-like `dict` and back wherever needed. 
+    - added unittests in `tests/test_util.py` for these functions.
+- implement RDFC1.0
+  - added new class `RDFC10` (subclass of `URDNA2015`) in `canon.py`
+  - added the RDFC1.0 test-suite in `tests/runtests.py`
+    - added support for testing blank-node identifier maps. 
+    - added support for testing with different hashing algorithms
+
+### Changed
+  - migrate `canon.py` to `rdflib`:
+    - now use `rdflib` for RDF term type checking (e.g., checking is something is a bnode), looping over triples/quads, nquads serialization and constructing RDF terms  (custom deepcopy is no longer needed) 
+    - move nquads parsing from`JsonLdProcessor.normalize()` to `URDNA2015.main()` so all parsing and serialization is handled by the same class. 
+    - move the main logic to `URDNA2015._canonicalize(self, dataset: Dataset)` while keeping input and output in `URDNA2015.main()`. The method `URDNA2015._canonicalize(self, dataset: Dataset)` accepts an `rdflib.Dataset` and returns a tuple with 
+        - the canonicalized result as a nquads `str` and 
+        - the blank node identifier map as `dict`.
+    - the method `URDNA2015 .main(self, dataset: str | dict | Dataset, options)` now 
+      - accepts a `rdflib.Dataset` object in addition to an nquads `str` or the original RDFJS-like`dict`. 
+      - returns 
+        - a `str`: the serialized nquads result, or 
+        - a `dict`: the result as RDFJS-like dataset or the blank node identifier map when the new parameter `outputMap` is `True`.
+    - the hashing algorithm is now an class attribute `URDNA2015.hash_algorithm` so it  configurable (required for RDFC1.0)
+    - the `permutations()` function now uses `itertools.permutations` instead of a custom implementation.
+    - replacements for rdflib's `_nq_row` and `_quoteLiteral` (these should eventually move to a fix for rdflib's nquads serializer).
+  - (re-)enabled all skipped URDNA2015, URDNA2012 tests in `tests/runtests.py`
+  - if the result of a test is a dict and the expected value is a string, the expected value is now parsed as JSON (needed for testing blank-node identifier maps).
+
 ## 3.3.0 - unreleased
 
 ### Added

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -508,6 +508,14 @@ class URGNA2012(URDNA2015):
     def create_hash(self):
         return hashlib.sha1()
 
+class RDFC10(URDNA2015):
+    """
+    RDFC10 implements the RDF Canonicalization algorithm version 1.0.
+    """
+    # TODO: Stub that uses URDNA2015 for now
+    def __init__(self):
+        URDNA2015.__init__(self)
+
 
 def permutations(elements):
     """

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -2,7 +2,7 @@ import copy
 import hashlib
 
 import rdflib
-from rdflib import XSD, BNode, Dataset, Literal, Node, URIRef
+from rdflib import XSD, BNode, Dataset, Literal, Node
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.plugins.serializers.nt import _quote_encode
 
@@ -29,7 +29,7 @@ class URDNA2015:
             and options['format'] != 'application/nquads'
         ):
             raise UnknownFormatError('Unknown output format.', options['format'])
-        
+
         # handle differtent input types: nquads string, dict (legacy ), or rdflib Dataset
         rdflib_dataset = Dataset()
         if isinstance(dataset, str):
@@ -47,21 +47,21 @@ class URDNA2015:
             rdflib_dataset = dataset
         else:
             raise ValueError(f'Unsupported dataset type: {type(dataset)}')
-        
+
         normalized = self._main(rdflib_dataset)
         with open(options.get('algorithm') + '.nq', 'w') as f:
             print(normalized, file=f)
-    
+
         # 8) Return the normalized dataset.
         if (
             options.get('format') == 'application/n-quads'
             or options.get('format') == 'application/nquads'
         ):
             return normalized
-        
+
         result = Dataset().parse(data=normalized, format='nquads')
         return to_legacy_dataset(result)
-        
+
     def _main(self, dataset: Dataset) -> str:
         self.dataset = dataset
         # 1) Create the normalization state.
@@ -196,7 +196,7 @@ class URDNA2015:
             p_n = p # Predicates are never BNodes in standard RDF
             o_n = map_node(o)
             g_n = map_node(g)
-            
+
             # Use modified version of rdflib's internal _nq_row for standardized string output
             line = self._nq_row((s_n, p_n, o_n),g_n)
 
@@ -240,7 +240,7 @@ class URDNA2015:
             s_n = self.modify_first_degree_component(id_, s)
             o_n = self.modify_first_degree_component(id_, o)
             g_n = self.modify_first_degree_component(id_, g)
-            
+
             # Use rdflib's internal _nt_row for standardized string output
             line = self._nq_row((s_n, p_n, o_n), g_n)
             nquads.append(line)
@@ -584,12 +584,32 @@ class RDFC10(URDNA2015):
             return f"{encoded}"
 
     def _quote_encode(self, l_: str) -> str:
-        return '"{}"'.format(
-            l_.replace("\\", "\\\\")
-            .replace("\n", "\\n")
-            .replace('"', '\\"')
-            .replace("\r", "\\r")
-        )
+        # Accept either an rdflib Literal or a plain string
+        s = str(l_)
+
+        parts = []
+        for ch in s:
+            code = ord(ch)
+            if ch == "\\":
+                parts.append('\\\\')
+            elif ch == '"':
+                parts.append('\\"')
+            elif ch == "\n":
+                parts.append('\\n')
+            elif ch == "\r":
+                parts.append('\\r')
+            elif ch == "\t":
+                parts.append('\\t')
+            elif code == 0x08:  # backspace
+                parts.append('\\b')
+            elif code == 0x0C:  # form feed
+                parts.append('\\f')
+            elif code == 0x0B or (code < 0x20) or (code == 0x7F):  # vertical tab -> use \u000B
+                parts.append(f'\\u{code:04X}')
+            else:
+                parts.append(ch)
+
+        return '"' + ''.join(parts) + '"'
 
 
 def permutations(elements):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -7,6 +7,8 @@ from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.plugins.serializers.nt import _quote_encode
 
 from pyld.identifier_issuer import IdentifierIssuer
+from pyld.util import from_legacy_dataset, to_legacy_dataset
+
 
 # TODO: use drop-in replacement to not serialize with xsd:string
 def _nq_row(triple, context):
@@ -730,93 +732,3 @@ class UnknownFormatError(ValueError):
     def __init__(self, message, format):
         Exception.__init__(self, message)
         self.format = format
-
-def to_legacy_dataset(dataset: Dataset) -> dict:
-    """
-    Transforms an rdflib.Dataset into the RDF.js-style dictionary structure,
-    ensuring Blank Node values start with '_:'.
-    """
-    compat_dataset = {}
-
-    for s, p, o, g in dataset.quads((None, None, None, None)):
-        # 1. Determine Graph Key
-        graph_id = '@default'
-        if g is not None and g != URIRef('urn:x-rdflib:default'):
-            graph_id = f"_:{str(g)}" if isinstance(g, BNode) else str(g)
-
-        if graph_id not in compat_dataset:
-            compat_dataset[graph_id] = []
-
-        # 2. Helper to convert nodes
-        def term_to_dict(node):
-            if isinstance(node, BNode):
-                # Ensure the value starts with _:
-                val = str(node)
-                if not val.startswith('_:'):
-                    val = f"_:{val}"
-                return {'type': 'blank node', 'value': val}
-
-            elif isinstance(node, URIRef):
-                return {'type': 'IRI', 'value': str(node)}
-
-            elif isinstance(node, Literal):
-                res = {'type': 'literal', 'value': str(node)}
-                if node.language:
-                    res['language'] = node.language
-                if node.datatype:
-                    res['datatype'] = str(node.datatype)
-                return res
-            raise ValueError(f'Illegal node type {type(node)}')
-
-        # 3. Build legacy quad
-        compat_dataset[graph_id].append({
-            'subject': term_to_dict(s),
-            'predicate': term_to_dict(p),
-            'object': term_to_dict(o)
-        })
-
-    return compat_dataset
-
-def from_legacy_dataset(dataset: dict) -> Dataset:
-    """
-    Converts legacy dict structure back into an rdflib.Dataset.
-    """
-    ds = Dataset()
-
-    for graph_name, triples in dataset.items():
-        # Handle graph name
-        if graph_name == '@default':
-            g = ds.default_graph
-        else:
-            # Check if graph name is a blank node or IRI
-            if graph_name.startswith('_:'):
-                g = ds.graph(BNode(graph_name[2:]))
-            else:
-                g = ds.graph(URIRef(graph_name))
-
-        for t in triples:
-            def to_node(comp):
-                val = comp['value']
-                if comp['type'] == 'blank node':
-                    # Strip '_:' because RDFLib adds it back internally
-                    return BNode(val[2:] if val.startswith('_:') else val)
-                elif comp['type'] == 'IRI':
-                    return URIRef(val)
-                elif comp['type'] == 'literal':
-                    return Literal(
-                        val,
-                        lang=comp.get('language'),
-                        datatype=URIRef(comp['datatype']) if comp.get('datatype') and not comp.get('language') else None,
-                        # Don't normalize literal values to prevent datetime issues
-                        # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
-                        normalize=False
-                    )
-                raise ValueError('Illegal component type {}'.format(comp['type']))
-
-            s = to_node(t['subject'])
-            p = to_node(t['predicate'])
-            o = to_node(t['object'])
-
-            ds.add((s, p, o, g))
-
-    return ds

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -3,21 +3,28 @@ import hashlib
 
 #from pyld.nquads import parse_nquads, serialize_nquad
 from rdflib import BNode, Dataset, Literal, Node, URIRef
-from rdflib.graph import _TripleType
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, _TripleType
 from rdflib.plugins.serializers.nt import _quote_encode
 
 from pyld.identifier_issuer import IdentifierIssuer
 
 # TODO: use drop-in replacement to not serialize with xsd:string
-def _nt_row(triple: _TripleType) -> str:
+def _nq_row(triple, context):
+    graph_name = context.n3() + " " if context and context != DATASET_DEFAULT_GRAPH_ID else ""
     if isinstance(triple[2], Literal):
-        return "%s %s %s .\n" % (
+        return "%s %s %s %s.\n" % (
             triple[0].n3(),
             triple[1].n3(),
             _quoteLiteral(triple[2]),
+            graph_name,
         )
     else:
-        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())
+        return "%s %s %s %s.\n" % (
+            triple[0].n3(),
+            triple[1].n3(),
+            triple[2].n3(),
+            graph_name,
+        )
 
 def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
     """A simpler version of term.Literal.n3()"""
@@ -230,7 +237,7 @@ class URDNA2015:
             g_n = map_node(g)
             
             # Use rdflib's internal _nt_row for standardized string output
-            line = _nt_row((s_n, p_n, o_n,g_n))
+            line = _nq_row((s_n, p_n, o_n),g_n)
 
             # 7.2) Add quad copy to the normalized dataset.
             normalized.append(line)
@@ -313,7 +320,7 @@ class URDNA2015:
             g_n = self.modify_first_degree_component(id_, g)
             
             # Use rdflib's internal _nt_row for standardized string output
-            line = _nt_row((s_n, p_n, o_n, g_n))
+            line = _nq_row((s_n, p_n, o_n), g_n)
             nquads.append(line)
 
         # 4) Sort nquads in lexicographical order.

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -51,7 +51,7 @@ class URDNA2015:
         else:
             raise ValueError(f'Unsupported dataset type: {type(dataset)}')
 
-        normalized, bnode_map = self._main(rdflib_dataset)
+        normalized, bnode_map = self._canonicalize(rdflib_dataset)
 
         # Merge any new bnode IDs from the parser into the id_map,
         # mapping old bnode IDs to their new canonical IDs
@@ -75,8 +75,14 @@ class URDNA2015:
         # If the output format is not nquads, return a dataset object.
         result = Dataset().parse(data=normalized, format='nquads')
         return to_legacy_dataset(result)
+    
+    def _canonicalize(self, dataset: Dataset) -> tuple[str, dict]:
+        """
+        Performs RDF Dataset Canonicalization on the given rdflib.Dataset
+        and returns the normalized output along with a map of blank node
+        identifiers to their canonical identifiers.
+        """
 
-    def _main(self, dataset: Dataset) -> tuple[str, dict]:
         self.dataset = dataset
         # 1) Create the normalization state.
 
@@ -274,11 +280,6 @@ class URDNA2015:
             return component
         return BNode("a") if str(component) == id_ else BNode("z")
 
-    # helper for getting a related predicate
-    def get_related_predicate(self, quad):
-        # quad is (s, p, o, g)
-        return f"<{str(quad[1])}>"
-
     # 4.7) Hash Related Blank Node
     def hash_related_blank_node(self, related, quad, issuer, position):
         # 1) Set the identifier to use for related, preferring first the
@@ -308,6 +309,11 @@ class URDNA2015:
         # 5) Return the hash that results from passing input through the hash
         # algorithm.
         return md.hexdigest()
+
+    # helper for getting a related predicate
+    def get_related_predicate(self, quad):
+        # quad is (s, p, o, g)
+        return f"<{str(quad[1])}>"
 
     # 4.8) Hash N-Degree Quads
     def hash_n_degree_quads(self, id_, issuer):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -20,6 +20,7 @@ class URDNA2015:
         self.hash_to_blank_nodes = {}
         self.canonical_issuer = IdentifierIssuer('_:c14n')
         self.dataset = None
+        self.hash_algorithm = hashlib.sha256
 
     # 4.4) Normalization Algorithm
     def main(self, dataset: str | dict | Dataset, options) -> str | dict:
@@ -454,7 +455,7 @@ class URDNA2015:
 
     # helper to create appropriate hash object
     def create_hash(self):
-        return hashlib.sha256()
+        return self.hash_algorithm()
 
     # helper to hash a list of nquads
     def hash_nquads(self, nquads):
@@ -497,6 +498,7 @@ class URGNA2012(URDNA2015):
 
     def __init__(self):
         URDNA2015.__init__(self)
+        self.hash_algorithm = hashlib.sha1
 
     # helper for modifying component during Hash First Degree Quads
     def modify_first_degree_component(self, id_: str, component: Node, key: str = None):
@@ -557,17 +559,18 @@ class URGNA2012(URDNA2015):
 
         return hash_to_related
 
-    # helper to create appropriate hash object
-    def create_hash(self):
-        return hashlib.sha1()
-
 class RDFC10(URDNA2015):
     """
     RDFC10 implements the RDF Canonicalization algorithm version 1.0.
     """
 
-    def __init__(self):
+    def __init__(self, hash_algorithm = None):
         URDNA2015.__init__(self)
+        # determine hash algorithm to use
+        if hash_algorithm is not None:
+            if hash_algorithm.lower() not in hashlib.algorithms_available:
+                raise UnknownFormatError('Unknown hash algorithm.', hash_algorithm)
+            self.hash_algorithm = getattr(hashlib, hash_algorithm.lower())
 
     def _quoteLiteral(self, l_: Literal) -> str:  # noqa: N802
         """A simpler version of term.Literal.n3()"""

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -4,6 +4,7 @@ import hashlib
 import rdflib
 from rdflib import XSD, BNode, Dataset, Literal, Node
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.plugins.parsers.nquads import NQuadsParser
 from rdflib.plugins.serializers.nt import _quote_encode
 
 from pyld.identifier_issuer import IdentifierIssuer
@@ -41,7 +42,8 @@ class URDNA2015:
             ):
                 raise UnknownFormatError('Unknown input format.', options['format'])
             rdflib.NORMALIZE_LITERALS = False
-            rdflib_dataset.parse(data=dataset, format='nquads')
+            parser = NQuadsParser()
+            parser.parse(rdflib.parser.StringInputSource(dataset), rdflib_dataset)
         elif isinstance(dataset, dict):
             rdflib_dataset = from_legacy_dataset(dataset)
         elif isinstance(dataset, Dataset):
@@ -49,9 +51,19 @@ class URDNA2015:
         else:
             raise ValueError(f'Unsupported dataset type: {type(dataset)}')
 
-        normalized = self._main(rdflib_dataset)
-        with open(options.get('algorithm') + '.nq', 'w') as f:
-            print(normalized, file=f)
+        normalized, bnode_map = self._main(rdflib_dataset)
+
+        # Merge any new bnode IDs from the parser into the id_map,
+        # mapping old bnode IDs to their new canonical IDs
+        if parser:
+            for k, v in parser._bnode_ids.items():
+                if bnode_map.get(str(v)) is not None:
+                    bnode_map[k] = bnode_map[str(v)]
+                del bnode_map[str(v)]
+
+        # If outputMap option is set, return the map of blank node identifiers.
+        if options.get('outputMap'):
+            return dict(sorted(bnode_map.items(), key=lambda item: item[1]))
 
         # 8) Return the normalized dataset.
         if (
@@ -60,10 +72,11 @@ class URDNA2015:
         ):
             return normalized
 
+        # If the output format is not nquads, return a dataset object.
         result = Dataset().parse(data=normalized, format='nquads')
         return to_legacy_dataset(result)
 
-    def _main(self, dataset: Dataset) -> str:
+    def _main(self, dataset: Dataset) -> tuple[str, dict]:
         self.dataset = dataset
         # 1) Create the normalization state.
 
@@ -175,6 +188,7 @@ class URDNA2015:
 
         # 7) For each quad, quad, in input dataset:
         normalized = []
+        id_map = {}
         for s, p, o, g in self.dataset.quads((None, None, None, None)):
             # 7.1) Create a copy, quad copy, of quad and replace any existing
             # blank node identifiers using the canonical identifiers previously
@@ -188,7 +202,7 @@ class URDNA2015:
                     cid = self.canonical_issuer.get_id(node_id)
                     if cid.startswith('_:'):
                         cid = cid[2:]  # Strip '_:' prefix for rdflib BNode compatibility
-
+                    id_map[node_id] = cid
                     return BNode(cid)
                 return node
 
@@ -208,7 +222,7 @@ class URDNA2015:
         normalized.sort()
 
         # return nquads string
-        return ''.join(normalized)
+        return ''.join(normalized), id_map
 
     # 4.6) Hash First Degree Quads
     def hash_first_degree_quads(self, id_):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -76,7 +76,7 @@ class URDNA2015:
         # If the output format is not nquads, return a dataset object.
         result = Dataset().parse(data=normalized, format='nquads')
         return to_legacy_dataset(result)
-    
+
     def _canonicalize(self, dataset: Dataset) -> tuple[str, dict]:
         """
         Performs RDF Dataset Canonicalization on the given rdflib.Dataset

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -41,7 +41,7 @@ class URDNA2015:
     def __init__(self):
         self.blank_node_info = {}
         self.hash_to_blank_nodes = {}
-        self.canonical_issuer = IdentifierIssuer('c14n')
+        self.canonical_issuer = IdentifierIssuer('_:c14n')
         self.quads = []
         self.POSITIONS = {'subject': 's', 'object': 'o', 'name': 'g'}
         self.dataset = None
@@ -216,8 +216,11 @@ class URDNA2015:
                 if isinstance(node, BNode):
                     node_id = str(node)
                     # Only issue a new ID if it's not already canonicalized
-                    if not node_id.startswith(self.canonical_issuer.prefix):
-                        return BNode(self.canonical_issuer.get_id(node_id))
+                    cid = self.canonical_issuer.get_id(node_id)
+                    if cid.startswith('_:'):
+                        cid = cid[2:]  # Strip '_:' prefix for rdflib BNode compatibility
+
+                    return BNode(cid)
                 return node
 
             # Transform Subject, Object, and Graph Name (Predicate is never a BNode in RDFC1.0)
@@ -526,7 +529,6 @@ class URDNA2015:
                     # whether component is a subject, object, graph name,
                     # respectively.
 
-                    # TODO: something is off here that makes last test fail
                     #related = component['value']
                     related = str(component)
                     #position = self.POSITIONS[key]
@@ -782,7 +784,7 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
                     return Literal(
                         val,
                         lang=comp.get('language'),
-                        datatype=URIRef(comp['datatype']) if comp.get('datatype') else None,
+                        datatype=URIRef(comp['datatype']) if comp.get('datatype') and not comp.get('language') else None,
                         # Don't normalize literal values to prevent datetime issues
                         # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
                         normalize=False

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -645,64 +645,57 @@ class RDFC10(URDNA2015):
     def __init__(self):
         URDNA2015.__init__(self)
 
-# def permutations(elements):
-    
-#     """
-#     Yield all permutations of the given elements in lexicographic order.
-
-#     Uses itertools.permutations on a sorted copy to avoid subtle bugs
-#     in a custom in-place implementation.
-#     """
-#     from itertools import permutations as _it_permutations
-#     els = sorted(elements)
-#     for perm in _it_permutations(els):
-#         yield list(perm)
-
 def permutations(elements):
     """
     Generates all of the possible permutations for the given list of elements.
+    Uses itertools.permutations on a sorted copy.
 
     :param elements: the list of elements to permutate.
     """
-    # begin with sorted elements
-    elements.sort()
-    # initialize directional info for permutation algorithm
-    left = {}
-    for v in elements:
-        left[v] = True
+    from itertools import permutations as _it_permutations
+    els = sorted(elements)
+    for perm in _it_permutations(els):
+        yield list(perm)
 
-    length = len(elements)
-    last = length - 1
-    while True:
-        yield elements
+#     # begin with sorted elements
+#     elements.sort()
+#     # initialize directional info for permutation algorithm
+#     left = {}
+#     for v in elements:
+#         left[v] = True
 
-        # Calculate the next permutation using the Steinhaus-Johnson-Trotter
-        # permutation algorithm.
+#     length = len(elements)
+#     last = length - 1
+#     while True:
+#         yield elements
 
-        # get largest mobile element k
-        # (mobile: element is greater than the one it is looking at)
-        k, pos = None, 0
-        for i in range(length):
-            e = elements[i]
-            is_left = left[e]
-            if (k is None or e > k) and (
-                (is_left and i > 0 and e > elements[i - 1])
-                or (not is_left and i < last and e > elements[i + 1])
-            ):
-                k, pos = e, i
+#         # Calculate the next permutation using the Steinhaus-Johnson-Trotter
+#         # permutation algorithm.
 
-        # no more permutations
-        if k is None:
-            return
+#         # get largest mobile element k
+#         # (mobile: element is greater than the one it is looking at)
+#         k, pos = None, 0
+#         for i in range(length):
+#             e = elements[i]
+#             is_left = left[e]
+#             if (k is None or e > k) and (
+#                 (is_left and i > 0 and e > elements[i - 1])
+#                 or (not is_left and i < last and e > elements[i + 1])
+#             ):
+#                 k, pos = e, i
 
-        # swap k and the element it is looking at
-        swap = pos - 1 if left[k] else pos + 1
-        elements[pos], elements[swap] = elements[swap], k
+#         # no more permutations
+#         if k is None:
+#             return
 
-        # reverse the direction of all elements larger than k
-        for i in range(length):
-            if elements[i] > k:
-                left[elements[i]] = not left[elements[i]]
+#         # swap k and the element it is looking at
+#         swap = pos - 1 if left[k] else pos + 1
+#         elements[pos], elements[swap] = elements[swap], k
+
+#         # reverse the direction of all elements larger than k
+#         for i in range(length):
+#             if elements[i] > k:
+#                 left[elements[i]] = not left[elements[i]]
 
 
 class UnknownFormatError(ValueError):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -6,7 +6,6 @@ from rdflib import BNode, Dataset, Literal, Node, URIRef
 from rdflib.graph import _TripleType
 from rdflib.plugins.serializers.nt import _quote_encode
 
-
 from pyld.identifier_issuer import IdentifierIssuer
 
 # TODO: use drop-in replacement to not serialize with xsd:string
@@ -57,6 +56,7 @@ class URDNA2015:
             raise UnknownFormatError('Unknown output format.', options['format'])
         
         rdflib_dataset = from_legacy_dataset(dataset)
+        # print(''.join(sorted(rdflib_dataset.serialize(format='nquads').splitlines(keepends=True))))
         normalized = self._main(rdflib_dataset)
     
         # 8) Return the normalized dataset.
@@ -224,7 +224,7 @@ class URDNA2015:
             s_n = map_node(s)
             p_n = p # Predicates are never BNodes in standard RDF
             o_n = map_node(o)
-            g_n = map_node(g if g else None)
+            g_n = map_node(g)
             
             # Use rdflib's internal _nt_row for standardized string output
             line = _nt_row((s_n, p_n, o_n,g_n))
@@ -530,7 +530,8 @@ class URDNA2015:
                     #related = component['value']
                     related = str(component)
                     #position = self.POSITIONS[key]
-                    position = ('s', None, 'p', 'g')[i]
+                    # correct position codes: subject='s', object='o', graph='g'
+                    position = ('s', None, 'o', 'g')[i]
                     hash = self.hash_related_blank_node(related, quad, issuer, position)
 
                     # 3.1.2) Add a mapping of hash to the blank node identifier
@@ -561,7 +562,7 @@ class URGNA2012(URDNA2015):
         URDNA2015.__init__(self)
 
     # helper for modifying component during Hash First Degree Quads
-    def modify_first_degree_component(self, id_: str, component: Node, key: str):
+    def modify_first_degree_component(self, id_: str, component: Node, key: str = None):
         if not isinstance(component, BNode):
             return component
         if key == 'name':
@@ -644,6 +645,18 @@ class RDFC10(URDNA2015):
     def __init__(self):
         URDNA2015.__init__(self)
 
+# def permutations(elements):
+    
+#     """
+#     Yield all permutations of the given elements in lexicographic order.
+
+#     Uses itertools.permutations on a sorted copy to avoid subtle bugs
+#     in a custom in-place implementation.
+#     """
+#     from itertools import permutations as _it_permutations
+#     els = sorted(elements)
+#     for perm in _it_permutations(els):
+#         yield list(perm)
 
 def permutations(elements):
     """
@@ -736,7 +749,7 @@ def to_legacy_dataset(dataset: Dataset) -> dict:
                 if node.datatype:
                     res['datatype'] = str(node.datatype)
                 return res
-            return None
+            raise ValueError(f'Illegal node type {type(node)}')
 
         # 3. Build legacy quad
         compat_dataset[graph_id].append({
@@ -756,7 +769,7 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
     for graph_name, triples in dataset.items():
         # Handle graph name
         if graph_name == '@default':
-            g = ds.default_context
+            g = ds.default_graph
         else:
             # Check if graph name is a blank node or IRI
             if graph_name.startswith('_:'):
@@ -766,22 +779,22 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
 
         for t in triples:
             def to_node(comp):
+                val = comp['value']
                 if comp['type'] == 'blank node':
                     # Strip '_:' because RDFLib adds it back internally
-                    val = comp['value']
                     return BNode(val[2:] if val.startswith('_:') else val)
                 elif comp['type'] == 'IRI':
-                    return URIRef(comp['value'])
+                    return URIRef(val)
                 elif comp['type'] == 'literal':
                     return Literal(
-                        comp['value'], 
-                        lang=comp.get('language'), 
+                        val,
+                        lang=comp.get('language'),
                         datatype=URIRef(comp['datatype']) if comp.get('datatype') else None,
                         # Don't normalize literal values to prevent datetime issues
                         # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
                         normalize=False
                     )
-                return None
+                raise ValueError('Illegal component type {}'.format(comp['type']))
 
             s = to_node(t['subject'])
             p = to_node(t['predicate'])

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -57,7 +57,6 @@ class URDNA2015:
             raise UnknownFormatError('Unknown output format.', options['format'])
         
         rdflib_dataset = from_legacy_dataset(dataset)
-        print(list(rdflib_dataset.quads()))
         normalized = self._main(rdflib_dataset)
     
         # 8) Return the normalized dataset.
@@ -74,7 +73,6 @@ class URDNA2015:
         
     def _main(self, dataset: Dataset):
         self.dataset = dataset
-
         # 1) Create the normalization state.
 
         # 2) For every quad in input dataset:
@@ -513,20 +511,26 @@ class URDNA2015:
             # 3.1) For each component in quad, if component is the subject,
             # object, and graph name and it is a blank node that is not
             # identified by identifier:
-            for key, component in quad.items():
-                if (
-                    key != 'predicate'
-                    and component['type'] == 'blank node'
-                    and component['value'] != id_
-                ):
+            # for key, component in quad.items():
+            #     if (
+            #         key != 'predicate'
+            #         and component['type'] == 'blank node'
+            #         and component['value'] != id_
+            #     ):
+            for i, component in enumerate(quad):
+                if i != 1 and isinstance(component, BNode) and str(component) != id_:
                     # 3.1.1) Set hash to the result of the Hash Related Blank
                     # Node algorithm, passing the blank node identifier for
                     # component as related, quad, path identifier issuer as
                     # issuer, and position as either s, o, or g based on
                     # whether component is a subject, object, graph name,
                     # respectively.
-                    related = component['value']
-                    position = self.POSITIONS[key]
+
+                    # TODO: something is off here that makes last test fail
+                    #related = component['value']
+                    related = str(component)
+                    #position = self.POSITIONS[key]
+                    position = ('s', None, 'p', 'g')[i]
                     hash = self.hash_related_blank_node(related, quad, issuer, position)
 
                     # 3.1.2) Add a mapping of hash to the blank node identifier
@@ -772,7 +776,10 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
                     return Literal(
                         comp['value'], 
                         lang=comp.get('language'), 
-                        datatype=URIRef(comp['datatype']) if comp.get('datatype') else None
+                        datatype=URIRef(comp['datatype']) if comp.get('datatype') else None,
+                        # Don't normalize literal values to prevent datetime issues
+                        # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
+                        normalize=False
                     )
                 return None
 

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -99,29 +99,6 @@ class URDNA2015:
         # 1) Create the normalization state.
 
         # 2) For every quad in input dataset:
-        # for graph_name, triples in dataset.items():
-        #     if graph_name == '@default':
-        #         graph_name = None
-        #     for triple in triples:
-        #         quad = triple
-        #         if graph_name is not None:
-        #             if graph_name.startswith('_:'):
-        #                 quad['name'] = {'type': 'blank node'}
-        #             else:
-        #                 quad['name'] = {'type': 'IRI'}
-        #             quad['name']['value'] = graph_name
-        #         self.quads.append(quad)
-
-        #         # 2.1) For each blank node that occurs in the quad, add a
-        #         # reference to the quad using the blank node identifier in the
-        #         # blank node to quads map, creating a new entry if necessary.
-        #         for key, component in quad.items():
-        #             if key == 'predicate' or component['type'] != 'blank node':
-        #                 continue
-        #             id_ = component['value']
-        #             self.blank_node_info.setdefault(id_, {'quads': []})['quads'].append(
-        #                 quad
-        #             )
         for s, p, o, g in dataset.quads((None, None, None, None)):
             # 2.1) For each blank node that occurs in the quad, add a
             # reference to the quad using the blank node identifier in the
@@ -252,39 +229,17 @@ class URDNA2015:
             o_n = map_node(o)
             g_n = map_node(g)
             
-            # Use rdflib's internal _nt_row for standardized string output
+            # Use rdflib's internal _nq_row for standardized string output
             line = _nq_row((s_n, p_n, o_n),g_n)
 
             # 7.2) Add quad copy to the normalized dataset.
             normalized.append(line)
-
-
-            # for key, component in quad.items():
-            #     if key == 'predicate':
-            #         continue
-            #     if component['type'] == 'blank node' and not component[
-            #         'value'
-            #     ].startswith(self.canonical_issuer.prefix):
-            #         component['value'] = self.canonical_issuer.get_id(
-            #             component['value']
-            #         )
-
-            # # 7.2) Add quad copy to the normalized dataset.
-            # normalized.append(serialize_nquad(quad))
 
         # sort normalized output
         normalized.sort()
 
         # return nquads string
         return ''.join(normalized)
-
-        # # 8) Return the normalized dataset.
-        # if (
-        #     options.get('format') == 'application/n-quads'
-        #     or options.get('format') == 'application/nquads'
-        # ):
-        #     return ''.join(normalized)
-        # return parse_nquads(''.join(normalized))
 
     # 4.6) Hash First Degree Quads
     def hash_first_degree_quads(self, id_):
@@ -302,24 +257,6 @@ class URDNA2015:
         quads = info['quads']
 
         # 3) For each quad quad in quads:
-        # for quad in quads:
-        #     # 3.1) Serialize the quad in N-Quads format with the following
-        #     # special rule:
-
-        #     # 3.1.1) If any component in quad is an blank node, then serialize
-        #     # it using a special identifier as follows:
-        #     copy = {}
-        #     for key, component in quad.items():
-        #         if key == 'predicate':
-        #             copy[key] = component
-        #             continue
-        #         # 3.1.2) If the blank node's existing blank node identifier
-        #         # matches the reference blank node identifier then use the
-        #         # blank node identifier _:a, otherwise, use the blank node
-        #         # identifier _:z.
-        #         copy[key] = self.modify_first_degree_component(id_, component, key)
-        #     nquads.append(serialize_nquad(copy))
-
         for s, p, o, g in quads:
             # 3.1) Serialize the quad in N-Quads format with the following
             # special rule:
@@ -359,14 +296,6 @@ class URDNA2015:
         # quad is (s, p, o, g)
         return f"<{str(quad[1])}>"
 
-    # # helper for modifying component during Hash First Degree Quads
-    # def modify_first_degree_component(self, id_, component, key):
-    #     if component['type'] != 'blank node':
-    #         return component
-    #     component = copy.deepcopy(component)
-    #     component['value'] = '_:a' if component['value'] == id_ else '_:z'
-    #     return component
-
     # 4.7) Hash Related Blank Node
     def hash_related_blank_node(self, related, quad, issuer, position):
         # 1) Set the identifier to use for related, preferring first the
@@ -396,10 +325,6 @@ class URDNA2015:
         # 5) Return the hash that results from passing input through the hash
         # algorithm.
         return md.hexdigest()
-
-    # # helper for getting a related predicate
-    # def get_related_predicate(self, quad):
-    #     return '<' + quad['predicate']['value'] + '>'
 
     # 4.8) Hash N-Degree Quads
     def hash_n_degree_quads(self, id_, issuer):
@@ -538,12 +463,6 @@ class URDNA2015:
             # 3.1) For each component in quad, if component is the subject,
             # object, and graph name and it is a blank node that is not
             # identified by identifier:
-            # for key, component in quad.items():
-            #     if (
-            #         key != 'predicate'
-            #         and component['type'] == 'blank node'
-            #         and component['value'] != id_
-            #     ):
             for i, component in enumerate(quad):
                 if i != 1 and isinstance(component, BNode) and str(component) != id_:
                     # 3.1.1) Set hash to the result of the Hash Related Blank
@@ -553,9 +472,7 @@ class URDNA2015:
                     # whether component is a subject, object, graph name,
                     # respectively.
 
-                    #related = component['value']
                     related = str(component)
-                    #position = self.POSITIONS[key]
                     # correct position codes: subject='s', object='o', graph='g'
                     position = ('s', None, 'o', 'g')[i]
                     hash = self.hash_related_blank_node(related, quad, issuer, position)
@@ -594,23 +511,10 @@ class URGNA2012(URDNA2015):
         if key == 'name':
             return BNode("g")
         return BNode("a") if str(component) == id_ else BNode("z")
-    
-    # def modify_first_degree_component(self, id_, component, key):
-    #     if component['type'] != 'blank node':
-    #         return component
-    #     component = copy.deepcopy(component)
-    #     if key == 'name':
-    #         component['value'] = '_:g'
-    #     else:
-    #         component['value'] = '_:a' if component['value'] == id_ else '_:z'
-    #     return component
 
     # helper for getting a related predicate
     def get_related_predicate(self, quad):
         return str(quad[1])
-    
-    # def get_related_predicate(self, quad):
-    #     return quad['predicate']['value']
 
     # helper for creating hash to related blank nodes map
     def create_hash_to_related(self, id_, issuer):
@@ -682,47 +586,6 @@ def permutations(elements):
     els = sorted(elements)
     for perm in _it_permutations(els):
         yield list(perm)
-
-#     # begin with sorted elements
-#     elements.sort()
-#     # initialize directional info for permutation algorithm
-#     left = {}
-#     for v in elements:
-#         left[v] = True
-
-#     length = len(elements)
-#     last = length - 1
-#     while True:
-#         yield elements
-
-#         # Calculate the next permutation using the Steinhaus-Johnson-Trotter
-#         # permutation algorithm.
-
-#         # get largest mobile element k
-#         # (mobile: element is greater than the one it is looking at)
-#         k, pos = None, 0
-#         for i in range(length):
-#             e = elements[i]
-#             is_left = left[e]
-#             if (k is None or e > k) and (
-#                 (is_left and i > 0 and e > elements[i - 1])
-#                 or (not is_left and i < last and e > elements[i + 1])
-#             ):
-#                 k, pos = e, i
-
-#         # no more permutations
-#         if k is None:
-#             return
-
-#         # swap k and the element it is looking at
-#         swap = pos - 1 if left[k] else pos + 1
-#         elements[pos], elements[swap] = elements[swap], k
-
-#         # reverse the direction of all elements larger than k
-#         for i in range(length):
-#             if elements[i] > k:
-#                 left[elements[i]] = not left[elements[i]]
-
 
 class UnknownFormatError(ValueError):
     """

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -35,6 +35,7 @@ class URDNA2015:
 
         # handle differtent input types: nquads string, dict (legacy ), or rdflib Dataset
         rdflib_dataset = Dataset()
+        parser = NQuadsParser()
         if isinstance(dataset, str):
             # Only support N-Quads string input for now
             if (
@@ -43,7 +44,6 @@ class URDNA2015:
             ):
                 raise UnknownFormatError('Unknown input format.', options['format'])
             rdflib.NORMALIZE_LITERALS = False
-            parser = NQuadsParser()
             parser.parse(rdflib.parser.StringInputSource(dataset), rdflib_dataset)
         elif isinstance(dataset, dict):
             rdflib_dataset = from_legacy_dataset(dataset)
@@ -56,11 +56,11 @@ class URDNA2015:
 
         # Merge any new bnode IDs from the parser into the id_map,
         # mapping old bnode IDs to their new canonical IDs
-        if parser:
-            for k, v in parser._bnode_ids.items():
-                if bnode_map.get(str(v)) is not None:
-                    bnode_map[k] = bnode_map[str(v)]
-                del bnode_map[str(v)]
+        for k, v in parser._bnode_ids.items():
+            bnode_id = str(v)
+            if bnode_id in bnode_map:
+                bnode_map[k] = bnode_map[bnode_id]
+                del bnode_map[bnode_id]
 
         # If outputMap option is set, return the map of blank node identifiers.
         if options.get('outputMap'):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -1,9 +1,9 @@
 import copy
 import hashlib
 
-#from pyld.nquads import parse_nquads, serialize_nquad
+import rdflib
 from rdflib import BNode, Dataset, Literal, Node, URIRef
-from rdflib.graph import DATASET_DEFAULT_GRAPH_ID, _TripleType
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.plugins.serializers.nt import _quote_encode
 
 from pyld.identifier_issuer import IdentifierIssuer
@@ -54,7 +54,7 @@ class URDNA2015:
         self.dataset = None
 
     # 4.4) Normalization Algorithm
-    def main(self, dataset, options):
+    def main(self, dataset: str | dict | Dataset, options) -> str | dict:
         # handle invalid output format
         if 'format' in options and (
             options['format'] != 'application/n-quads'
@@ -62,8 +62,24 @@ class URDNA2015:
         ):
             raise UnknownFormatError('Unknown output format.', options['format'])
         
-        rdflib_dataset = from_legacy_dataset(dataset)
-        # print(''.join(sorted(rdflib_dataset.serialize(format='nquads').splitlines(keepends=True))))
+        # handle differtent input types: nquads string, dict (legacy ), or rdflib Dataset
+        rdflib_dataset = Dataset()
+        if isinstance(dataset, str):
+            # Only support N-Quads string input for now
+            if (
+                options['inputFormat'] != 'application/n-quads'
+                and options['inputFormat'] != 'application/nquads'
+            ):
+                raise UnknownFormatError('Unknown input format.', options['format'])
+            rdflib.NORMALIZE_LITERALS = False
+            rdflib_dataset.parse(data=dataset, format='nquads')
+        elif isinstance(dataset, dict):
+            rdflib_dataset = from_legacy_dataset(dataset)
+        elif isinstance(dataset, Dataset):
+            rdflib_dataset = dataset
+        else:
+            raise ValueError(f'Unsupported dataset type: {type(dataset)}')
+        
         normalized = self._main(rdflib_dataset)
     
         # 8) Return the normalized dataset.
@@ -71,14 +87,12 @@ class URDNA2015:
             options.get('format') == 'application/n-quads'
             or options.get('format') == 'application/nquads'
         ):
-            return ''.join(normalized)
-            #return result.serialize(format="nt")
+            return normalized
         
-        result = Dataset().parse(data=''.join(normalized))
+        result = Dataset().parse(data=normalized, format='nquads')
         return to_legacy_dataset(result)
-        #return parse_nquads(''.join(normalized))
         
-    def _main(self, dataset: Dataset):
+    def _main(self, dataset: Dataset) -> str:
         self.dataset = dataset
         # 1) Create the normalization state.
 
@@ -259,7 +273,8 @@ class URDNA2015:
         # sort normalized output
         normalized.sort()
 
-        return normalized
+        # return nquads string
+        return ''.join(normalized)
 
         # # 8) Return the normalized dataset.
         # if (

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -2,45 +2,13 @@ import copy
 import hashlib
 
 import rdflib
-from rdflib import BNode, Dataset, Literal, Node, URIRef
+from rdflib import XSD, BNode, Dataset, Literal, Node, URIRef
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.plugins.serializers.nt import _quote_encode
 
 from pyld.identifier_issuer import IdentifierIssuer
 from pyld.util import from_legacy_dataset, to_legacy_dataset
 
-
-# TODO: use drop-in replacement to not serialize with xsd:string
-def _nq_row(triple, context):
-    graph_name = context.n3() + " " if context and context != DATASET_DEFAULT_GRAPH_ID else ""
-    if isinstance(triple[2], Literal):
-        return "%s %s %s %s.\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            _quoteLiteral(triple[2]),
-            graph_name,
-        )
-    else:
-        return "%s %s %s %s.\n" % (
-            triple[0].n3(),
-            triple[1].n3(),
-            triple[2].n3(),
-            graph_name,
-        )
-
-def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
-    """A simpler version of term.Literal.n3()"""
-
-    encoded = _quote_encode(l_)
-
-    if l_.language:
-        if l_.datatype:
-            raise Exception("Literal has datatype AND language!")
-        return "%s@%s" % (encoded, l_.language)
-    elif l_.datatype and l_.datatype != URIRef('http://www.w3.org/2001/XMLSchema#string'):
-        return "%s^^<%s>" % (encoded, l_.datatype)
-    else:
-        return "%s" % encoded
 
 class URDNA2015:
     """
@@ -51,8 +19,6 @@ class URDNA2015:
         self.blank_node_info = {}
         self.hash_to_blank_nodes = {}
         self.canonical_issuer = IdentifierIssuer('_:c14n')
-        self.quads = []
-        self.POSITIONS = {'subject': 's', 'object': 'o', 'name': 'g'}
         self.dataset = None
 
     # 4.4) Normalization Algorithm
@@ -83,6 +49,8 @@ class URDNA2015:
             raise ValueError(f'Unsupported dataset type: {type(dataset)}')
         
         normalized = self._main(rdflib_dataset)
+        with open(options.get('algorithm') + '.nq', 'w') as f:
+            print(normalized, file=f)
     
         # 8) Return the normalized dataset.
         if (
@@ -229,8 +197,8 @@ class URDNA2015:
             o_n = map_node(o)
             g_n = map_node(g)
             
-            # Use rdflib's internal _nq_row for standardized string output
-            line = _nq_row((s_n, p_n, o_n),g_n)
+            # Use modified version of rdflib's internal _nq_row for standardized string output
+            line = self._nq_row((s_n, p_n, o_n),g_n)
 
             # 7.2) Add quad copy to the normalized dataset.
             normalized.append(line)
@@ -274,7 +242,7 @@ class URDNA2015:
             g_n = self.modify_first_degree_component(id_, g)
             
             # Use rdflib's internal _nt_row for standardized string output
-            line = _nq_row((s_n, p_n, o_n), g_n)
+            line = self._nq_row((s_n, p_n, o_n), g_n)
             nquads.append(line)
 
         # 4) Sort nquads in lexicographical order.
@@ -495,6 +463,32 @@ class URDNA2015:
             md.update(nquad.encode('utf8'))
         return md.hexdigest()
 
+    # TODO: use drop-in replacements to not serialize with xsd:string; better to solve this at the rdflib level
+    def _nq_row(self, triple, context):
+        graph_name = (
+            context.n3() + " "
+            if context and context != DATASET_DEFAULT_GRAPH_ID
+            else ""
+        )
+        if isinstance(triple[2], Literal):
+            return f"{triple[0].n3()} {triple[1].n3()} {self._quoteLiteral(triple[2])} {graph_name}.\n"
+        else:
+            return f"{triple[0].n3()} {triple[1].n3()} {triple[2].n3()} {graph_name}.\n"
+
+    def _quoteLiteral(self, l_: Literal) -> str:  # noqa: N802
+        """A simpler version of term.Literal.n3()"""
+
+        encoded = _quote_encode(l_)
+
+        if l_.language:
+            if l_.datatype:
+                raise Exception("Literal has datatype AND language!")
+            return f"{encoded}@{l_.language}"
+        elif l_.datatype and l_.datatype != XSD.string:
+            return f"{encoded}^^<{l_.datatype}>"
+        else:
+            return f"{encoded}"
+
 
 class URGNA2012(URDNA2015):
     """
@@ -571,9 +565,32 @@ class RDFC10(URDNA2015):
     """
     RDFC10 implements the RDF Canonicalization algorithm version 1.0.
     """
-    # TODO: Stub that uses URDNA2015 for now
+
     def __init__(self):
         URDNA2015.__init__(self)
+
+    def _quoteLiteral(self, l_: Literal) -> str:  # noqa: N802
+        """A simpler version of term.Literal.n3()"""
+
+        encoded = self._quote_encode(l_)
+
+        if l_.language:
+            if l_.datatype:
+                raise Exception("Literal has datatype AND language!")
+            return f"{encoded}@{l_.language}"
+        elif l_.datatype and l_.datatype != XSD.string:
+            return f"{encoded}^^<{l_.datatype}>"
+        else:
+            return f"{encoded}"
+
+    def _quote_encode(self, l_: str) -> str:
+        return '"{}"'.format(
+            l_.replace("\\", "\\\\")
+            .replace("\n", "\\n")
+            .replace('"', '\\"')
+            .replace("\r", "\\r")
+        )
+
 
 def permutations(elements):
     """

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -21,6 +21,7 @@ class URDNA2015:
         self.hash_to_blank_nodes = {}
         self.canonical_issuer = IdentifierIssuer('_:c14n')
         self.dataset = None
+        self.POSITIONS = ['s', 'p', 'o', 'g']
         self.hash_algorithm = hashlib.sha256
 
     # 4.4) Normalization Algorithm
@@ -463,7 +464,7 @@ class URDNA2015:
 
                     related = str(component)
                     # correct position codes: subject='s', object='o', graph='g'
-                    position = ('s', None, 'o', 'g')[i]
+                    position = self.POSITIONS[i]
                     hash = self.hash_related_blank_node(related, quad, issuer, position)
 
                     # 3.1.2) Add a mapping of hash to the blank node identifier

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -1,9 +1,38 @@
 import copy
 import hashlib
 
-from pyld.identifier_issuer import IdentifierIssuer
-from pyld.nquads import parse_nquads, serialize_nquad
+#from pyld.nquads import parse_nquads, serialize_nquad
+from rdflib import BNode, Dataset, Literal, Node, URIRef
+from rdflib.graph import _TripleType
+from rdflib.plugins.serializers.nt import _quote_encode
 
+
+from pyld.identifier_issuer import IdentifierIssuer
+
+# TODO: use drop-in replacement to not serialize with xsd:string
+def _nt_row(triple: _TripleType) -> str:
+    if isinstance(triple[2], Literal):
+        return "%s %s %s .\n" % (
+            triple[0].n3(),
+            triple[1].n3(),
+            _quoteLiteral(triple[2]),
+        )
+    else:
+        return "%s %s %s .\n" % (triple[0].n3(), triple[1].n3(), triple[2].n3())
+
+def _quoteLiteral(l_: Literal) -> str:  # noqa: N802
+    """A simpler version of term.Literal.n3()"""
+
+    encoded = _quote_encode(l_)
+
+    if l_.language:
+        if l_.datatype:
+            raise Exception("Literal has datatype AND language!")
+        return "%s@%s" % (encoded, l_.language)
+    elif l_.datatype and l_.datatype != URIRef('http://www.w3.org/2001/XMLSchema#string'):
+        return "%s^^<%s>" % (encoded, l_.datatype)
+    else:
+        return "%s" % encoded
 
 class URDNA2015:
     """
@@ -13,9 +42,10 @@ class URDNA2015:
     def __init__(self):
         self.blank_node_info = {}
         self.hash_to_blank_nodes = {}
-        self.canonical_issuer = IdentifierIssuer('_:c14n')
+        self.canonical_issuer = IdentifierIssuer('c14n')
         self.quads = []
         self.POSITIONS = {'subject': 's', 'object': 'o', 'name': 'g'}
+        self.dataset = None
 
     # 4.4) Normalization Algorithm
     def main(self, dataset, options):
@@ -25,33 +55,60 @@ class URDNA2015:
             and options['format'] != 'application/nquads'
         ):
             raise UnknownFormatError('Unknown output format.', options['format'])
+        
+        rdflib_dataset = from_legacy_dataset(dataset)
+        print(list(rdflib_dataset.quads()))
+        normalized = self._main(rdflib_dataset)
+    
+        # 8) Return the normalized dataset.
+        if (
+            options.get('format') == 'application/n-quads'
+            or options.get('format') == 'application/nquads'
+        ):
+            return ''.join(normalized)
+            #return result.serialize(format="nt")
+        
+        result = Dataset().parse(data=''.join(normalized))
+        return to_legacy_dataset(result)
+        #return parse_nquads(''.join(normalized))
+        
+    def _main(self, dataset: Dataset):
+        self.dataset = dataset
 
         # 1) Create the normalization state.
 
         # 2) For every quad in input dataset:
-        for graph_name, triples in dataset.items():
-            if graph_name == '@default':
-                graph_name = None
-            for triple in triples:
-                quad = triple
-                if graph_name is not None:
-                    if graph_name.startswith('_:'):
-                        quad['name'] = {'type': 'blank node'}
-                    else:
-                        quad['name'] = {'type': 'IRI'}
-                    quad['name']['value'] = graph_name
-                self.quads.append(quad)
+        # for graph_name, triples in dataset.items():
+        #     if graph_name == '@default':
+        #         graph_name = None
+        #     for triple in triples:
+        #         quad = triple
+        #         if graph_name is not None:
+        #             if graph_name.startswith('_:'):
+        #                 quad['name'] = {'type': 'blank node'}
+        #             else:
+        #                 quad['name'] = {'type': 'IRI'}
+        #             quad['name']['value'] = graph_name
+        #         self.quads.append(quad)
 
-                # 2.1) For each blank node that occurs in the quad, add a
-                # reference to the quad using the blank node identifier in the
-                # blank node to quads map, creating a new entry if necessary.
-                for key, component in quad.items():
-                    if key == 'predicate' or component['type'] != 'blank node':
-                        continue
-                    id_ = component['value']
-                    self.blank_node_info.setdefault(id_, {'quads': []})['quads'].append(
-                        quad
-                    )
+        #         # 2.1) For each blank node that occurs in the quad, add a
+        #         # reference to the quad using the blank node identifier in the
+        #         # blank node to quads map, creating a new entry if necessary.
+        #         for key, component in quad.items():
+        #             if key == 'predicate' or component['type'] != 'blank node':
+        #                 continue
+        #             id_ = component['value']
+        #             self.blank_node_info.setdefault(id_, {'quads': []})['quads'].append(
+        #                 quad
+        #             )
+        for s, p, o, g in dataset.quads((None, None, None, None)):
+            # 2.1) For each blank node that occurs in the quad, add a
+            # reference to the quad using the blank node identifier in the
+            # blank node to quads map, creating a new entry if necessary.
+            for component in (s, o, g if g else None):
+                if isinstance(component, BNode):
+                    id_ = str(component)
+                    self.blank_node_info.setdefault(id_, {'quads': []})['quads'].append((s, p, o, g))
 
         # 3) Create a list of non-normalized blank node identifiers and
         # populate it using the keys from the blank node to quads map.
@@ -151,33 +208,58 @@ class URDNA2015:
 
         # 7) For each quad, quad, in input dataset:
         normalized = []
-        for quad in self.quads:
+        for s, p, o, g in self.dataset.quads((None, None, None, None)):
             # 7.1) Create a copy, quad copy, of quad and replace any existing
             # blank node identifiers using the canonical identifiers previously
             # issued by canonical issuer. Note: We optimize away the copy here.
-            for key, component in quad.items():
-                if key == 'predicate':
-                    continue
-                if component['type'] == 'blank node' and not component[
-                    'value'
-                ].startswith(self.canonical_issuer.prefix):
-                    component['value'] = self.canonical_issuer.get_id(
-                        component['value']
-                    )
+
+            # Helper to map nodes
+            def map_node(node):
+                if isinstance(node, BNode):
+                    node_id = str(node)
+                    # Only issue a new ID if it's not already canonicalized
+                    if not node_id.startswith(self.canonical_issuer.prefix):
+                        return BNode(self.canonical_issuer.get_id(node_id))
+                return node
+
+            # Transform Subject, Object, and Graph Name (Predicate is never a BNode in RDFC1.0)
+            s_n = map_node(s)
+            p_n = p # Predicates are never BNodes in standard RDF
+            o_n = map_node(o)
+            g_n = map_node(g if g else None)
+            
+            # Use rdflib's internal _nt_row for standardized string output
+            line = _nt_row((s_n, p_n, o_n,g_n))
 
             # 7.2) Add quad copy to the normalized dataset.
-            normalized.append(serialize_nquad(quad))
+            normalized.append(line)
+
+
+            # for key, component in quad.items():
+            #     if key == 'predicate':
+            #         continue
+            #     if component['type'] == 'blank node' and not component[
+            #         'value'
+            #     ].startswith(self.canonical_issuer.prefix):
+            #         component['value'] = self.canonical_issuer.get_id(
+            #             component['value']
+            #         )
+
+            # # 7.2) Add quad copy to the normalized dataset.
+            # normalized.append(serialize_nquad(quad))
 
         # sort normalized output
         normalized.sort()
 
-        # 8) Return the normalized dataset.
-        if (
-            options.get('format') == 'application/n-quads'
-            or options.get('format') == 'application/nquads'
-        ):
-            return ''.join(normalized)
-        return parse_nquads(''.join(normalized))
+        return normalized
+
+        # # 8) Return the normalized dataset.
+        # if (
+        #     options.get('format') == 'application/n-quads'
+        #     or options.get('format') == 'application/nquads'
+        # ):
+        #     return ''.join(normalized)
+        # return parse_nquads(''.join(normalized))
 
     # 4.6) Hash First Degree Quads
     def hash_first_degree_quads(self, id_):
@@ -195,23 +277,43 @@ class URDNA2015:
         quads = info['quads']
 
         # 3) For each quad quad in quads:
-        for quad in quads:
+        # for quad in quads:
+        #     # 3.1) Serialize the quad in N-Quads format with the following
+        #     # special rule:
+
+        #     # 3.1.1) If any component in quad is an blank node, then serialize
+        #     # it using a special identifier as follows:
+        #     copy = {}
+        #     for key, component in quad.items():
+        #         if key == 'predicate':
+        #             copy[key] = component
+        #             continue
+        #         # 3.1.2) If the blank node's existing blank node identifier
+        #         # matches the reference blank node identifier then use the
+        #         # blank node identifier _:a, otherwise, use the blank node
+        #         # identifier _:z.
+        #         copy[key] = self.modify_first_degree_component(id_, component, key)
+        #     nquads.append(serialize_nquad(copy))
+
+        for s, p, o, g in quads:
             # 3.1) Serialize the quad in N-Quads format with the following
             # special rule:
 
             # 3.1.1) If any component in quad is an blank node, then serialize
             # it using a special identifier as follows:
-            copy = {}
-            for key, component in quad.items():
-                if key == 'predicate':
-                    copy[key] = component
-                    continue
-                # 3.1.2) If the blank node's existing blank node identifier
-                # matches the reference blank node identifier then use the
-                # blank node identifier _:a, otherwise, use the blank node
-                # identifier _:z.
-                copy[key] = self.modify_first_degree_component(id_, component, key)
-            nquads.append(serialize_nquad(copy))
+            p_n = p # Predicates are never BNodes in standard RDF
+
+            # 3.1.2) If the blank node's existing blank node identifier
+            # matches the reference blank node identifier then use the
+            # blank node identifier _:a, otherwise, use the blank node
+            # Replace current BNode with _:a, others with _:z for hashing
+            s_n = self.modify_first_degree_component(id_, s)
+            o_n = self.modify_first_degree_component(id_, o)
+            g_n = self.modify_first_degree_component(id_, g)
+            
+            # Use rdflib's internal _nt_row for standardized string output
+            line = _nt_row((s_n, p_n, o_n, g_n))
+            nquads.append(line)
 
         # 4) Sort nquads in lexicographical order.
         nquads.sort()
@@ -222,12 +324,23 @@ class URDNA2015:
         return info['hash']
 
     # helper for modifying component during Hash First Degree Quads
-    def modify_first_degree_component(self, id_, component, key):
-        if component['type'] != 'blank node':
+    def modify_first_degree_component(self, id_: str, component: Node, key: str = None):
+        if not isinstance(component, BNode):
             return component
-        component = copy.deepcopy(component)
-        component['value'] = '_:a' if component['value'] == id_ else '_:z'
-        return component
+        return BNode("a") if str(component) == id_ else BNode("z")
+
+    # helper for getting a related predicate
+    def get_related_predicate(self, quad):
+        # quad is (s, p, o, g)
+        return f"<{str(quad[1])}>"
+
+    # # helper for modifying component during Hash First Degree Quads
+    # def modify_first_degree_component(self, id_, component, key):
+    #     if component['type'] != 'blank node':
+    #         return component
+    #     component = copy.deepcopy(component)
+    #     component['value'] = '_:a' if component['value'] == id_ else '_:z'
+    #     return component
 
     # 4.7) Hash Related Blank Node
     def hash_related_blank_node(self, related, quad, issuer, position):
@@ -259,9 +372,9 @@ class URDNA2015:
         # algorithm.
         return md.hexdigest()
 
-    # helper for getting a related predicate
-    def get_related_predicate(self, quad):
-        return '<' + quad['predicate']['value'] + '>'
+    # # helper for getting a related predicate
+    # def get_related_predicate(self, quad):
+    #     return '<' + quad['predicate']['value'] + '>'
 
     # 4.8) Hash N-Degree Quads
     def hash_n_degree_quads(self, id_, issuer):
@@ -444,19 +557,29 @@ class URGNA2012(URDNA2015):
         URDNA2015.__init__(self)
 
     # helper for modifying component during Hash First Degree Quads
-    def modify_first_degree_component(self, id_, component, key):
-        if component['type'] != 'blank node':
+    def modify_first_degree_component(self, id_: str, component: Node, key: str):
+        if not isinstance(component, BNode):
             return component
-        component = copy.deepcopy(component)
         if key == 'name':
-            component['value'] = '_:g'
-        else:
-            component['value'] = '_:a' if component['value'] == id_ else '_:z'
-        return component
+            return BNode("g")
+        return BNode("a") if str(component) == id_ else BNode("z")
+    
+    # def modify_first_degree_component(self, id_, component, key):
+    #     if component['type'] != 'blank node':
+    #         return component
+    #     component = copy.deepcopy(component)
+    #     if key == 'name':
+    #         component['value'] = '_:g'
+    #     else:
+    #         component['value'] = '_:a' if component['value'] == id_ else '_:z'
+    #     return component
 
     # helper for getting a related predicate
     def get_related_predicate(self, quad):
-        return quad['predicate']['value']
+        return str(quad[1])
+    
+    # def get_related_predicate(self, quad):
+    #     return quad['predicate']['value']
 
     # helper for creating hash to related blank nodes map
     def create_hash_to_related(self, id_, issuer):
@@ -470,16 +593,17 @@ class URGNA2012(URDNA2015):
 
         # 3) For each quad in quads:
         for quad in quads:
+            s, p , o, g = quad
             # 3.1) If the quad's subject is a blank node that does not match
             # identifier, set hash to the result of the Hash Related Blank Node
             # algorithm, passing the blank node identifier for subject as
             # related, quad, path identifier issuer as issuer, and p as
             # position.
             if (
-                quad['subject']['type'] == 'blank node'
-                and quad['subject']['value'] != id_
+                isinstance(s, BNode)
+                and str(s) != id_
             ):
-                related = quad['subject']['value']
+                related = str(s)
                 position = 'p'
             # 3.2) Otherwise, if quad's object is a blank node that does
             # not match identifier, to the result of the Hash Related Blank
@@ -487,10 +611,10 @@ class URGNA2012(URDNA2015):
             # as related, quad, path identifier issuer as issuer, and r
             # as position.
             elif (
-                quad['object']['type'] == 'blank node'
-                and quad['object']['value'] != id_
+                isinstance(o, BNode)
+                and str(o) != id_
             ):
-                related = quad['object']['value']
+                related = str(o)
                 position = 'r'
             # 3.3) Otherwise, continue to the next quad.
             else:
@@ -572,3 +696,90 @@ class UnknownFormatError(ValueError):
     def __init__(self, message, format):
         Exception.__init__(self, message)
         self.format = format
+
+def to_legacy_dataset(dataset: Dataset) -> dict:
+    """
+    Transforms an rdflib.Dataset into the RDF.js-style dictionary structure,
+    ensuring Blank Node values start with '_:'.
+    """
+    compat_dataset = {}
+
+    for s, p, o, g in dataset.quads((None, None, None, None)):
+        # 1. Determine Graph Key
+        graph_id = '@default'
+        if g is not None and g != URIRef('urn:x-rdflib:default'):
+            graph_id = f"_:{str(g)}" if isinstance(g, BNode) else str(g)
+
+        if graph_id not in compat_dataset:
+            compat_dataset[graph_id] = []
+
+        # 2. Helper to convert nodes
+        def term_to_dict(node):
+            if isinstance(node, BNode):
+                # Ensure the value starts with _:
+                val = str(node)
+                if not val.startswith('_:'):
+                    val = f"_:{val}"
+                return {'type': 'blank node', 'value': val}
+
+            elif isinstance(node, URIRef):
+                return {'type': 'IRI', 'value': str(node)}
+
+            elif isinstance(node, Literal):
+                res = {'type': 'literal', 'value': str(node)}
+                if node.language:
+                    res['language'] = node.language
+                if node.datatype:
+                    res['datatype'] = str(node.datatype)
+                return res
+            return None
+
+        # 3. Build legacy quad
+        compat_dataset[graph_id].append({
+            'subject': term_to_dict(s),
+            'predicate': term_to_dict(p),
+            'object': term_to_dict(o)
+        })
+
+    return compat_dataset
+
+def from_legacy_dataset(dataset: dict) -> Dataset:
+    """
+    Converts legacy dict structure back into an rdflib.Dataset.
+    """
+    ds = Dataset()
+
+    for graph_name, triples in dataset.items():
+        # Handle graph name
+        if graph_name == '@default':
+            g = ds.default_context
+        else:
+            # Check if graph name is a blank node or IRI
+            if graph_name.startswith('_:'):
+                g = ds.graph(BNode(graph_name[2:]))
+            else:
+                g = ds.graph(URIRef(graph_name))
+
+        for t in triples:
+            def to_node(comp):
+                if comp['type'] == 'blank node':
+                    # Strip '_:' because RDFLib adds it back internally
+                    val = comp['value']
+                    return BNode(val[2:] if val.startswith('_:') else val)
+                elif comp['type'] == 'IRI':
+                    return URIRef(comp['value'])
+                elif comp['type'] == 'literal':
+                    return Literal(
+                        comp['value'], 
+                        lang=comp.get('language'), 
+                        datatype=URIRef(comp['datatype']) if comp.get('datatype') else None
+                    )
+                return None
+
+            s = to_node(t['subject'])
+            p = to_node(t['predicate'])
+            o = to_node(t['object'])
+
+            ds.add((s, p, o, g))
+
+    return ds

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -4,6 +4,7 @@ import hashlib
 import rdflib
 from rdflib import XSD, BNode, Dataset, Literal, Node
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+from rdflib.parser import StringInputSource
 from rdflib.plugins.parsers.nquads import NQuadsParser
 from rdflib.plugins.serializers.nt import _quote_encode
 
@@ -44,7 +45,7 @@ class URDNA2015:
             ):
                 raise UnknownFormatError('Unknown input format.', options['format'])
             rdflib.NORMALIZE_LITERALS = False
-            parser.parse(rdflib.parser.StringInputSource(dataset), rdflib_dataset)
+            parser.parse(StringInputSource(dataset), rdflib_dataset)
         elif isinstance(dataset, dict):
             rdflib_dataset = from_legacy_dataset(dataset)
         elif isinstance(dataset, Dataset):

--- a/lib/pyld/canon.py
+++ b/lib/pyld/canon.py
@@ -612,29 +612,29 @@ class RDFC10(URDNA2015):
         # Accept either an rdflib Literal or a plain string
         s = str(l_)
 
-        parts = []
+        parts = ''
         for ch in s:
             code = ord(ch)
             if ch == "\\":
-                parts.append('\\\\')
+                parts += '\\\\'
             elif ch == '"':
-                parts.append('\\"')
+                parts += '\\"'
             elif ch == "\n":
-                parts.append('\\n')
+                parts += '\\n'
             elif ch == "\r":
-                parts.append('\\r')
+                parts += '\\r'
             elif ch == "\t":
-                parts.append('\\t')
+                parts += '\\t'
             elif code == 0x08:  # backspace
-                parts.append('\\b')
+                parts += '\\b'
             elif code == 0x0C:  # form feed
-                parts.append('\\f')
+                parts += '\\f'
             elif code == 0x0B or (code < 0x20) or (code == 0x7F):  # vertical tab -> use \u000B
-                parts.append(f'\\u{code:04X}')
+                parts += f'\\u{code:04X}'
             else:
-                parts.append(ch)
+                parts += ch
 
-        return '"' + ''.join(parts) + '"'
+        return '"' + parts + '"'
 
 
 def permutations(elements):

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3959,6 +3959,10 @@ class JsonLdProcessor:
                     object['value'] = _canonicalize_double(float_value)
                     object['datatype'] = XSD_DOUBLE
                     return object
+            # Numbers without fractions but larger or equal to 1e21 should be double
+            elif _is_integer(value) and value >= 1e21:
+                object['value'] = _canonicalize_double(value)
+                object['datatype'] = XSD_DOUBLE
             elif _is_integer(value):
                 object['value'] = str(int(value))
                 object['datatype'] = datatype or XSD_INTEGER

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -889,8 +889,8 @@ class JsonLdProcessor:
             'application/n-quads' for N-Quads.
           [documentLoader(url, options)] the document loader
             (default: _default_document_loader).
-          [outputMap] if True, the function will return a map of blank node 
-            identifiers to their normalized identifiers instead of the 
+          [outputMap] if True, the function will return a map of blank node
+            identifiers to their normalized identifiers instead of the
             normalized dataset (default: False).
 
         :return: the normalized output or the map of blank node identifiers.
@@ -942,7 +942,7 @@ class JsonLdProcessor:
         except UnknownFormatError as cause:
             raise JsonLdError(
                 str(cause),
-                'jsonld.UnknownFormat', 
+                'jsonld.UnknownFormat',
                 {'format': cause.format}) from cause
 
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -925,7 +925,7 @@ class JsonLdProcessor:
 
         # do normalization
         if options['algorithm'] == 'RDFC10':
-            algorithm = RDFC10()
+            algorithm = RDFC10(hash_algorithm = options.get('hashAlgorithm'))
         elif options['algorithm'] == 'URDNA2015':
             algorithm = URDNA2015()
         # assume URGNA2012

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3960,9 +3960,9 @@ class JsonLdProcessor:
                     object['datatype'] = XSD_DOUBLE
                     return object
             # Numbers without fractions but larger or equal to 1e21 should be double
-            elif _is_integer(value) and value >= 1e21:
+            elif _is_integer(value) and abs(value) >= 1e21:
                 object['value'] = _canonicalize_double(value)
-                object['datatype'] = XSD_DOUBLE
+                object['datatype'] = datatype or XSD_DOUBLE
             elif _is_integer(value):
                 object['value'] = str(int(value))
                 object['datatype'] = datatype or XSD_INTEGER

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -909,14 +909,7 @@ class JsonLdProcessor:
 
         try:
             if 'inputFormat' in options:
-                if (
-                    options['inputFormat'] != 'application/n-quads'
-                    and options['inputFormat'] != 'application/nquads'
-                ):
-                    raise JsonLdError(
-                        'Unknown normalization input format.', 'jsonld.NormalizeError'
-                    )
-                dataset = JsonLdProcessor.parse_nquads(input_)
+                dataset = input_
             else:
                 # convert to RDF dataset then do normalization
                 opts = dict(options)

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -34,7 +34,7 @@ from frozendict import frozendict
 
 from c14n.Canonicalize import canonicalize
 from pyld.__about__ import __copyright__, __license__, __version__
-from pyld.canon import URDNA2015, URGNA2012, UnknownFormatError
+from pyld.canon import RDFC10, URDNA2015, URGNA2012, UnknownFormatError
 from pyld.identifier_issuer import IdentifierIssuer
 from pyld.nquads import (
     ParserError,
@@ -877,8 +877,8 @@ class JsonLdProcessor:
 
         :param input_: the JSON-LD input to normalize.
         :param options: the options to use.
-          [algorithm] the algorithm to use: `URDNA2015` or `URGNA2012`
-            (default: `URGNA2012`).
+          [algorithm] the algorithm to use: `RDFC10`, `URDNA2015` or `URGNA2012`
+            (default: `RDFC10`).
           [base] the base IRI to use.
           [contextResolver] internal use only.
           [inputFormat] the format if input is not JSON-LD:
@@ -892,7 +892,7 @@ class JsonLdProcessor:
         """
         # set default options
         options = options.copy() if options else {}
-        options.setdefault('algorithm', 'URGNA2012')
+        options.setdefault('algorithm', 'RDFC10')
         options.setdefault('base', input_ if _is_string(input_) else '')
         options.setdefault('documentLoader', _default_document_loader)
         options.setdefault(
@@ -902,7 +902,7 @@ class JsonLdProcessor:
         options.setdefault('extractAllScripts', True)
         options.setdefault('processingMode', 'json-ld-1.1')
 
-        if options['algorithm'] not in ['URDNA2015', 'URGNA2012']:
+        if options['algorithm'] not in ['RDFC10', 'URDNA2015', 'URGNA2012']:
             raise JsonLdError(
                 'Unsupported normalization algorithm.', 'jsonld.NormalizeError'
             )
@@ -931,16 +931,23 @@ class JsonLdProcessor:
             ) from cause
 
         # do normalization
-        if options['algorithm'] == 'URDNA2015':
-            try:
-                return URDNA2015().main(dataset, options)
-            except UnknownFormatError as cause:
-                raise JsonLdError(
-                    str(cause), 'jsonld.UnknownFormat', {'format': cause.format}
-                ) from cause
-
+        if options['algorithm'] == 'RDFC10':
+            algorithm = RDFC10()
+        elif options['algorithm'] == 'URDNA2015':
+            algorithm = URDNA2015()
         # assume URGNA2012
-        return URGNA2012().main(dataset, options)
+        else:
+            algorithm = URGNA2012()
+
+        try:
+            # TODO: find a good way to expose identifier map
+            return algorithm.main(dataset, options) #, algorithm.hash_to_blank_nodes
+        except UnknownFormatError as cause:
+            raise JsonLdError(
+                str(cause),
+                'jsonld.UnknownFormat', 
+                {'format': cause.format}) from cause
+
 
     def from_rdf(self, dataset, options):
         """

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -879,6 +879,8 @@ class JsonLdProcessor:
         :param options: the options to use.
           [algorithm] the algorithm to use: `RDFC10`, `URDNA2015` or `URGNA2012`
             (default: `RDFC10`).
+          [hashAlgorithm] the hashing algorithm to use; only applicable to `RDFC10`.
+            (default: `SHA256`).
           [base] the base IRI to use.
           [contextResolver] internal use only.
           [inputFormat] the format if input is not JSON-LD:
@@ -887,8 +889,11 @@ class JsonLdProcessor:
             'application/n-quads' for N-Quads.
           [documentLoader(url, options)] the document loader
             (default: _default_document_loader).
+          [outputMap] if True, the function will return a map of blank node 
+            identifiers to their normalized identifiers instead of the 
+            normalized dataset (default: False).
 
-        :return: the normalized output.
+        :return: the normalized output or the map of blank node identifiers.
         """
         # set default options
         options = options.copy() if options else {}
@@ -933,8 +938,7 @@ class JsonLdProcessor:
             algorithm = URGNA2012()
 
         try:
-            # TODO: find a good way to expose identifier map
-            return algorithm.main(dataset, options) #, algorithm.hash_to_blank_nodes
+            return algorithm.main(dataset, options)
         except UnknownFormatError as cause:
             raise JsonLdError(
                 str(cause),

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3861,9 +3861,7 @@ class JsonLdProcessor:
                     predicate['value'] = property
 
                     # convert list, value or node object to triple
-                    object = self._object_to_rdf(
-                        item, issuer, triples, options.get('rdfDirection')
-                    )
+                    object = self._object_to_rdf(item, issuer, triples, options)
                     # skip None objects (they are relative IRIs)
                     if object is not None:
                         triples.append(
@@ -3875,7 +3873,7 @@ class JsonLdProcessor:
                         )
         return triples
 
-    def _list_to_rdf(self, list_, issuer, triples, rdf_direction):
+    def _list_to_rdf(self, list_, issuer, triples, options):
         """
         Converts a @list value into a linked list of blank node RDF triples
         (and RDF collection).
@@ -3883,7 +3881,7 @@ class JsonLdProcessor:
         :param list_: the @list value.
         :param issuer: the IdentifierIssuer for issuing blank node identifiers.
         :param triples: the array of triples to append to.
-        :param rdf_direction: for creating datatyped literals.
+        :param options: the RDF serialization options.
 
         :return: the head of the list
         """
@@ -3897,7 +3895,7 @@ class JsonLdProcessor:
         subject = result
 
         for item in list_:
-            object = self._object_to_rdf(item, issuer, triples, rdf_direction)
+            object = self._object_to_rdf(item, issuer, triples, options)
             next = {'type': 'blank node', 'value': issuer.get_id()}
             triples.append({'subject': subject, 'predicate': first, 'object': object})
             triples.append({'subject': subject, 'predicate': rest, 'object': next})
@@ -3906,13 +3904,13 @@ class JsonLdProcessor:
 
         # tail of list
         if last:
-            object = self._object_to_rdf(last, issuer, triples, rdf_direction)
+            object = self._object_to_rdf(last, issuer, triples, options)
             triples.append({'subject': subject, 'predicate': first, 'object': object})
             triples.append({'subject': subject, 'predicate': rest, 'object': nil})
 
         return result
 
-    def _object_to_rdf(self, item, issuer, triples, rdf_direction):
+    def _object_to_rdf(self, item, issuer, triples, options):
         """
         Converts a JSON-LD value object to an RDF literal or a JSON-LD string
         or node object to an RDF resource.
@@ -3920,7 +3918,7 @@ class JsonLdProcessor:
         :param item: the JSON-LD value or node object.
         :param issuer: the IdentifierIssuer for issuing blank node identifiers.
         :param triples: the array of triples to append list entries to.
-        :param rdf_direction: for creating directional literals.
+        :param options: the RDF serialization options.
 
         :return: the RDF literal or RDF resource.
         """
@@ -3930,6 +3928,7 @@ class JsonLdProcessor:
             object['type'] = 'literal'
             value = item['@value']
             datatype = item.get('@type')
+            rdf_direction = options.get('rdfDirection')
 
             # convert to XSD datatypes as appropriate
             if datatype == '@json':
@@ -3959,8 +3958,11 @@ class JsonLdProcessor:
                     object['value'] = _canonicalize_double(float_value)
                     object['datatype'] = XSD_DOUBLE
                     return object
-            # Numbers without fractions but larger or equal to 1e21 should be double
-            elif _is_integer(value) and abs(value) >= 1e21:
+            elif (
+                options['processingMode'] == 'json-ld-1.1'
+                and _is_integer(value)
+                and abs(value) >= 1e21
+            ):
                 object['value'] = _canonicalize_double(value)
                 object['datatype'] = datatype or XSD_DOUBLE
             elif _is_integer(value):
@@ -4019,7 +4021,7 @@ class JsonLdProcessor:
                 object['datatype'] = datatype or XSD_STRING
         # convert list object to RDF
         elif _is_list(item):
-            list_ = self._list_to_rdf(item['@list'], issuer, triples, rdf_direction)
+            list_ = self._list_to_rdf(item['@list'], issuer, triples, options)
             object['value'] = list_['value']
             object['type'] = list_['type']
         # convert string/node object to RDF

--- a/lib/pyld/util.py
+++ b/lib/pyld/util.py
@@ -8,7 +8,7 @@ def to_legacy_dataset(dataset: Dataset) -> dict:
     Transforms an rdflib.Dataset into the RDF.js-style dictionary structure,
     ensuring Blank Node values start with '_:'.
     """
-    compat_dataset = {}
+    compat_dataset = {'@default':[]}
 
     for s, p, o, g in dataset.quads((None, None, None, None)):
         # 1. Determine Graph Key
@@ -60,18 +60,25 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
 
     for graph_name, triples in dataset.items():
         # Handle graph name
-        if graph_name == '@default':
-            g = ds.default_graph
-        else:
-            # Check if graph name is a blank node or IRI
-            if graph_name.startswith('_:'):
+        try:
+            if graph_name == '@default':
+                g = ds.default_graph
+            elif graph_name.startswith('_:'):
+                # Check if graph name is a blank node or IRI
                 g = ds.graph(BNode(graph_name[2:]))
             else:
                 g = ds.graph(URIRef(graph_name))
+        except Exception as err:
+            raise ValueError(f'Illegal graph name: {graph_name}') from err
 
         for t in triples:
+            if not all(k in t for k in ('subject', 'predicate', 'object')):
+                raise ValueError(f'Illegal quad structure: {t}')
 
             def to_node(comp):
+                if not isinstance(comp, dict) or 'type' not in comp or 'value' not in comp:
+                    raise ValueError(f'Illegal quad structure: {comp}')
+
                 val = comp['value']
                 if comp['type'] == 'blank node':
                     # Strip '_:' because RDFLib adds it back internally

--- a/lib/pyld/util.py
+++ b/lib/pyld/util.py
@@ -61,47 +61,60 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
     for graph_name, triples in dataset.items():
         # Handle graph name
         try:
-            if graph_name == '@default':
-                g = ds.default_graph
-            elif graph_name.startswith('_:'):
-                # Check if graph name is a blank node or IRI
-                g = ds.graph(BNode(graph_name[2:]))
-            else:
-                g = ds.graph(URIRef(graph_name))
+            g = from_legacy_graph(graph_name, ds.default_graph)
         except Exception as err:
             raise ValueError(f'Illegal graph name: {graph_name}') from err
 
         for t in triples:
-            if not all(k in t for k in ('subject', 'predicate', 'object')):
-                raise ValueError(f'Illegal quad structure: {t}')
-
-            def to_node(comp):
-                if not isinstance(comp, dict) or 'type' not in comp or 'value' not in comp:
-                    raise ValueError(f'Illegal quad structure: {comp}')
-
-                val = comp['value']
-                if comp['type'] == 'blank node':
-                    # Strip '_:' because RDFLib adds it back internally
-                    return BNode(val[2:] if val.startswith('_:') else val)
-                elif comp['type'] == 'IRI':
-                    return URIRef(val)
-                elif comp['type'] == 'literal':
-                    return Literal(
-                        val,
-                        lang=comp.get('language'),
-                        datatype=URIRef(comp['datatype'])
-                        if comp.get('datatype') and not comp.get('language')
-                        else None,
-                        # Don't normalize literal values to prevent datetime issues
-                        # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
-                        normalize=False,
-                    )
-                raise ValueError('Illegal component type {}'.format(comp['type']))
-
-            s = to_node(t['subject'])
-            p = to_node(t['predicate'])
-            o = to_node(t['object'])
-
+            s, p, o = from_legacy_triple(t)
             ds.add((s, p, o, g))
 
     return ds
+
+def from_legacy_graph(graph: str, default_graph = DATASET_DEFAULT_GRAPH_ID) -> URIRef | BNode:
+    """
+    Converts a legacy graph name into an rdflib URIRef or BNode.
+    """
+    if graph == '@default':
+        return default_graph
+    # Check if graph name is a blank node or IRI
+    elif graph.startswith('_:'):
+        return BNode(graph[2:])
+    else:
+        return URIRef(graph)
+
+def from_legacy_triple(triple: dict, normalize=False) -> tuple:
+    """
+    Converts a legacy triple dict into an rdflib triple tuple.
+    """
+    if not all(k in triple for k in ('subject', 'predicate', 'object')):
+        raise ValueError(f'Illegal quad structure: {triple}')
+
+    def to_node(comp):
+        if not isinstance(comp, dict) or 'type' not in comp or 'value' not in comp:
+            raise ValueError(f'Illegal quad structure: {comp}')
+
+        val = comp['value']
+        if comp['type'] == 'blank node':
+            # Strip '_:' because RDFLib adds it back internally
+            return BNode(val[2:] if val.startswith('_:') else val)
+        elif comp['type'] == 'IRI':
+            return URIRef(val)
+        elif comp['type'] == 'literal':
+            return Literal(
+                val,
+                lang=comp.get('language'),
+                datatype=URIRef(comp['datatype'])
+                if comp.get('datatype') and not comp.get('language')
+                else None,
+                # Don't normalize literal values to prevent datetime issues
+                # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
+                normalize=normalize,
+            )
+        raise ValueError('Illegal component type {}'.format(comp['type']))
+
+    s = to_node(triple['subject'])
+    p = to_node(triple['predicate'])
+    o = to_node(triple['object'])
+
+    return (s, p, o)

--- a/lib/pyld/util.py
+++ b/lib/pyld/util.py
@@ -1,0 +1,100 @@
+from rdflib import BNode, Dataset, Literal, URIRef
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+
+
+# Helpers for converting between rdflib.Dataset and legacy dict structure used in pyld
+def to_legacy_dataset(dataset: Dataset) -> dict:
+    """
+    Transforms an rdflib.Dataset into the RDF.js-style dictionary structure,
+    ensuring Blank Node values start with '_:'.
+    """
+    compat_dataset = {}
+
+    for s, p, o, g in dataset.quads((None, None, None, None)):
+        # 1. Determine Graph Key
+        graph_id = '@default'
+        if g is not None and g != DATASET_DEFAULT_GRAPH_ID:
+            graph_id = f"_:{str(g)}" if isinstance(g, BNode) else str(g)
+
+        if graph_id not in compat_dataset:
+            compat_dataset[graph_id] = []
+
+        # 2. Helper to convert nodes
+        def term_to_dict(node):
+            if isinstance(node, BNode):
+                # Ensure the value starts with _:
+                val = str(node)
+                if not val.startswith('_:'):
+                    val = f"_:{val}"
+                return {'type': 'blank node', 'value': val}
+
+            elif isinstance(node, URIRef):
+                return {'type': 'IRI', 'value': str(node)}
+
+            elif isinstance(node, Literal):
+                res = {'type': 'literal', 'value': str(node)}
+                if node.language:
+                    res['language'] = node.language
+                if node.datatype:
+                    res['datatype'] = str(node.datatype)
+                return res
+            raise ValueError(f'Illegal node type {type(node)}')
+
+        # 3. Build legacy quad
+        compat_dataset[graph_id].append(
+            {
+                'subject': term_to_dict(s),
+                'predicate': term_to_dict(p),
+                'object': term_to_dict(o),
+            }
+        )
+
+    return compat_dataset
+
+
+def from_legacy_dataset(dataset: dict) -> Dataset:
+    """
+    Converts legacy dict structure back into an rdflib.Dataset.
+    """
+    ds = Dataset()
+
+    for graph_name, triples in dataset.items():
+        # Handle graph name
+        if graph_name == '@default':
+            g = ds.default_graph
+        else:
+            # Check if graph name is a blank node or IRI
+            if graph_name.startswith('_:'):
+                g = ds.graph(BNode(graph_name[2:]))
+            else:
+                g = ds.graph(URIRef(graph_name))
+
+        for t in triples:
+
+            def to_node(comp):
+                val = comp['value']
+                if comp['type'] == 'blank node':
+                    # Strip '_:' because RDFLib adds it back internally
+                    return BNode(val[2:] if val.startswith('_:') else val)
+                elif comp['type'] == 'IRI':
+                    return URIRef(val)
+                elif comp['type'] == 'literal':
+                    return Literal(
+                        val,
+                        lang=comp.get('language'),
+                        datatype=URIRef(comp['datatype'])
+                        if comp.get('datatype') and not comp.get('language')
+                        else None,
+                        # Don't normalize literal values to prevent datetime issues
+                        # TODO: this means only rdflib.Dataset() created with normalization turned off will work properly.
+                        normalize=False,
+                    )
+                raise ValueError('Illegal component type {}'.format(comp['type']))
+
+            s = to_node(t['subject'])
+            p = to_node(t['predicate'])
+            o = to_node(t['object'])
+
+            ds.add((s, p, o, g))
+
+    return ds

--- a/lib/pyld/util.py
+++ b/lib/pyld/util.py
@@ -61,7 +61,7 @@ def from_legacy_dataset(dataset: dict) -> Dataset:
     for graph_name, triples in dataset.items():
         # Handle graph name
         try:
-            g = from_legacy_graph(graph_name, ds.default_graph)
+            g = from_legacy_graph(graph_name, ds.default_graph.identifier)
         except Exception as err:
             raise ValueError(f'Illegal graph name: {graph_name}') from err
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aiohttp; python_version >= '3.5'
 lxml
 cachetools
 frozendict
+rdflib

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'cachetools',
         'frozendict',
         'lxml',
+        'rdflib',
     ],
     extras_require={
         'requests': ['requests'],
@@ -64,5 +65,6 @@ setup(
         'requests-cache': ['requests-cache>=1.3'],
         'cachetools': ['cachetools'],
         'frozendict': ['frozendict'],
+        'rdflib': ['rdflib'],
     }
 )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1013,8 +1013,6 @@ TEST_TYPES = {
                 # rel vocab
                 '.*toRdf-manifest#te111$',
                 '.*toRdf-manifest#te112$',
-                # number fixes
-                '.*toRdf-manifest#trt01$',
                 # well formed
                 '.*toRdf-manifest#twf05$',
                 # uncategorized

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -683,7 +683,7 @@ def create_test_options(opts=None):
             if k not in http_options:
                 options[k] = v
         options['documentLoader'] = create_document_loader(test)
-        # options['hashAlgorithm'] = test.data.get('hashAlgorithm')
+        options['hashAlgorithm'] = test.data.get('hashAlgorithm')
 
         if 'expandContext' in options:
             filename = os.path.join(test.dirname, options['expandContext'])

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -477,6 +477,10 @@ class Test(unittest.TestCase):
                 else:
                     assert_results_equal(result, expect)
             elif not self.is_negative:
+                # If the result is a dict and the expected value is a string, 
+                # the expected value is probably JSON.
+                if isinstance(result, dict) and isinstance(expect, str):
+                    expect = json.loads(expect)
                 # Perform order-independent equivalence test
                 if not equal_unordered(result, expect):
                     if _running_under_pytest():
@@ -1038,11 +1042,7 @@ TEST_TYPES = {
     },
     'rdfn:Urgna2012EvalTest': {
         'pending': {'idRegex': []},
-        'skip': {
-            'idRegex': [
-                '.*manifest-urgna2012#test060$',
-            ]
-        },
+        'skip': {'idRegex': []},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1057,11 +1057,7 @@ TEST_TYPES = {
     },
     'rdfn:Urdna2015EvalTest': {
         'pending': {'idRegex': []},
-        'skip': {
-            'idRegex': [
-                #'.*manifest-urdna2015#test060$',
-            ]
-        },
+        'skip': {'idRegex': []},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1075,15 +1071,8 @@ TEST_TYPES = {
         ],
     },
     'rdfc:RDFC10EvalTest': {
-        'pending': {
-            'idRegex': [
-                #'.*#test060c$',
-                #'.*#test075c$'
-            ]
-        },
-        'skip': {
-            'idRegex': []
-        },
+        'pending': {'idRegex': []},
+        'skip': {'idRegex': []},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1094,24 +1083,24 @@ TEST_TYPES = {
             })
         ]
     },
-    # 'rdfc:RDFC10MapTest': {
-    #     'pending': {
-    #         'idRegex': [
-    #         ]
-    #     },
-    #     'skip': {
-    #         'idRegex': []
-    #     },
-    #     'fn': 'normalize',
-    #     'params': [
-    #         read_test_property('action'),
-    #         create_test_options({
-    #             'algorithm': 'RDFC10',
-    #             'inputFormat': 'application/n-quads',
-    #             'format': 'application/n-quads'
-    #         })
-    #     ]
-    # }
+    'rdfc:RDFC10MapTest': {
+        'pending': {
+            'idRegex': []
+        },
+        'skip': {
+            'idRegex': []
+        },
+        'fn': 'normalize',
+        'params': [
+            read_test_property('action'),
+            create_test_options({
+                'algorithm': 'RDFC10',
+                'inputFormat': 'application/n-quads',
+                'format': 'application/n-quads',
+                'outputMap': True
+            })
+        ]
+    }
 }
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1057,7 +1057,7 @@ TEST_TYPES = {
         'pending': {'idRegex': []},
         'skip': {
             'idRegex': [
-                '.*manifest-urdna2015#test060$',
+                #'.*manifest-urdna2015#test060$',
             ]
         },
         'fn': 'normalize',
@@ -1075,8 +1075,8 @@ TEST_TYPES = {
     'rdfc:RDFC10EvalTest': {
         'pending': {
             'idRegex': [
-                '.*#test060c$',
-                '.*#test075c$'
+                #'.*#test060c$',
+                #'.*#test075c$'
             ]
         },
         'skip': {

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -477,7 +477,7 @@ class Test(unittest.TestCase):
                 else:
                     assert_results_equal(result, expect)
             elif not self.is_negative:
-                # If the result is a dict and the expected value is a string, 
+                # If the result is a dict and the expected value is a string,
                 # the expected value is probably JSON.
                 if isinstance(result, dict) and isinstance(expect, str):
                     expect = json.loads(expect)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -91,12 +91,14 @@ LOCAL_BASES = [
     'https://w3c.github.io/json-ld-api/tests',
     'https://w3c.github.io/json-ld-framing/tests',
     'https://github.com/json-ld/normalization/tests',
+    'https://w3c.github.io/rdf-canon/tests/vocab#'
 ]
 
 SPEC_DIRS = [
     '../specifications/json-ld-api/tests/',
     '../specifications/json-ld-framing/tests/',
     '../specifications/normalization/tests/',
+    '../specifications/rdf-canon/tests/'
 ]
 
 # NOTE: The following TestRunner class can be removed because pytest now
@@ -1070,6 +1072,44 @@ TEST_TYPES = {
             ),
         ],
     },
+    'rdfc:RDFC10EvalTest': {
+        'pending': {
+            'idRegex': [
+                '.*#test060c$',
+                '.*#test075c$'
+            ]
+        },
+        'skip': {
+            'idRegex': []
+        },
+        'fn': 'normalize',
+        'params': [
+            read_test_property('action'),
+            create_test_options({
+                'algorithm': 'RDFC10',
+                'inputFormat': 'application/n-quads',
+                'format': 'application/n-quads'
+            })
+        ]
+    },
+    # 'rdfc:RDFC10MapTest': {
+    #     'pending': {
+    #         'idRegex': [
+    #         ]
+    #     },
+    #     'skip': {
+    #         'idRegex': []
+    #     },
+    #     'fn': 'normalize',
+    #     'params': [
+    #         read_test_property('action'),
+    #         create_test_options({
+    #             'algorithm': 'RDFC10',
+    #             'inputFormat': 'application/n-quads',
+    #             'format': 'application/n-quads'
+    #         })
+    #     ]
+    # }
 }
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -679,6 +679,8 @@ def create_test_options(opts=None):
             if k not in http_options:
                 options[k] = v
         options['documentLoader'] = create_document_loader(test)
+        # options['hashAlgorithm'] = test.data.get('hashAlgorithm')
+
         if 'expandContext' in options:
             filename = os.path.join(test.dirname, options['expandContext'])
             options['expandContext'] = read_json(filename)

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -947,6 +947,35 @@ class TestToRdf:
         result = jsonld.to_rdf(input)
         assert result == expected
 
+    def test_large_integer_to_rdf_double_conversion_processing_mode(self):
+        """
+        In json-ld-1.1 processing mode, large integers should be emitted as xsd:double,
+        while in json-ld-1.0 processing mode, they should be kept as xsd:integer.
+        """
+        input = {
+            '@id': 'http://example.com/s',
+            'http://example.com/p': 1000000000000000000000,
+        }
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+        assert nquads == (
+            '<http://example.com/s> <http://example.com/p> '
+            '"1.0E21"^^<http://www.w3.org/2001/XMLSchema#double> .\n'
+        )
+
+        nquads = jsonld.to_rdf(
+            input,
+            options={
+                'format': 'application/n-quads',
+                'processingMode': 'json-ld-1.0',
+            },
+        )
+        assert nquads == (
+            '<http://example.com/s> <http://example.com/p> '
+            '"1000000000000000000000"'
+            '^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
+        )
+
     def test_compound_literal_direction_without_language(self):
         """
         Values with @direction should become compound literals during to_rdf

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,320 @@
+import pytest
+from rdflib import BNode, Dataset, Literal, URIRef
+from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+
+from pyld.util import from_legacy_dataset, to_legacy_dataset
+
+
+class TestToLegacyDataset:
+    """A comprehensive class-based test suite for `to_legacy_dataset` split into granular tests."""
+
+    def setup_method(self):
+        """Initialize a clean Dataset before each test."""
+        self.dataset = Dataset()
+
+    def test_to_legacy_dataset_empty_dataset_returns_minimal_structure(self):
+        """Ensure an empty dataset produces a minimal dict with exactly one graph ('@default') and no quads."""
+        result = to_legacy_dataset(Dataset())
+        assert len(result) == 1
+        assert '@default' in result
+        assert len(result['@default']) == 0
+
+    def test_to_legacy_dataset_handles_blank_subject(self):
+        """Ensure blank node subjects are correctly converted to dict with type 'blank node' and value prefixed by '_:'."""
+        self.dataset.add((BNode('b1'), URIRef('p1'), Literal('o1', lang='en')))
+        result = to_legacy_dataset(self.dataset)
+
+        # Get the quad from @default graph
+        quads_in_graph = result['@default']
+        assert len(quads_in_graph) == 1
+
+        subject_entry = quads_in_graph[0]['subject']
+        assert subject_entry['type'] == 'blank node'
+        assert subject_entry['value'].startswith('_:')
+        assert (
+            subject_entry['value'][2:] == 'b1'
+        )  # Check that the original BNode identifier is preserved after prefix
+
+    def test_to_legacy_dataset_handles_blank_object(self):
+        """Ensure blank node objects are correctly converted to dict with type 'blank node' and prefixed value."""
+        self.dataset.add((URIRef('s2'), URIRef('p2'), BNode('b3')))
+        result = to_legacy_dataset(self.dataset)
+
+        # Get the quad from @default graph
+        quads_in_graph = result['@default']
+        assert len(quads_in_graph) == 1
+
+        object_entry = quads_in_graph[0]['object']
+        assert object_entry['type'] == 'blank node'
+        assert object_entry['value'].startswith('_:')
+        assert (
+            object_entry['value'][2:] == 'b3'
+        )  # Check that the original BNode identifier is preserved after prefix
+
+    def test_to_legacy_dataset_preserves_literal_language(self):
+        """Ensure literal objects with language are preserved in the output as a 'language' field."""
+
+        self.dataset.add((URIRef('s1'), URIRef('p2'), Literal('o3', lang='fr')))
+        result = to_legacy_dataset(self.dataset)
+
+        # Get the quad from @default graph
+        quads_in_graph = result['@default']
+        assert len(quads_in_graph) == 1
+
+        object_entry = quads_in_graph[0]['object']
+        assert object_entry.get('language') is not None
+        assert object_entry['language'] == 'fr'
+
+    def test_to_legacy_dataset_preserves_literal_datatype(self):
+        """Ensure literal objects with a datatype are preserved in the output as 'datatype' field."""
+        self.dataset.add(
+            (
+                URIRef('s1'),
+                URIRef('p2'),
+                Literal("x", datatype="http://example.org/float"),
+            ),
+        )
+        result = to_legacy_dataset(self.dataset)
+
+        # Get the quad from @default graph
+        quads_in_graph = result['@default']
+        assert len(quads_in_graph) == 1
+
+        object_entry = quads_in_graph[0]['object']
+        assert object_entry.get('datatype') is not None
+        assert object_entry['datatype'] == "http://example.org/float"
+
+    def test_to_legacy_dataset_correctly_maps_graph(self):
+        """Ensure graph key is correctly derived."""
+        self.dataset.add(
+            (
+                URIRef('s1'),
+                URIRef('p2'),
+                Literal('o3'),
+                URIRef('http://example.org/graph'),
+            )
+        )
+        result = to_legacy_dataset(self.dataset)
+
+        # There should be two graphs: '@default' (empty) and 'http://example.org/graph' (with one quad)
+        assert len(result.keys()) == 2
+
+        # Check that '@default' graph exists and is empty
+        assert '@default' in result
+        assert len(result['@default']) == 0
+
+        # Check that 'http://example.org/graph' exists and contains the quad
+        assert 'http://example.org/graph' in result
+        assert len(result['http://example.org/graph']) == 1
+
+    def test_to_legacy_dataset_correctly_maps_bnode_graph(self):
+        """Ensure graph key is correctly prefixed with '_' for BNodes"""
+        self.dataset.add((URIRef('s1'), URIRef('p2'), Literal('o3'), BNode('g4')))
+        result = to_legacy_dataset(self.dataset)
+
+        # There should be two graphs: '@default' (empty) and '_:g4' (with one quad)
+        assert len(result.keys()) == 2
+
+        # Check that '@default' graph exists and is empty
+        assert '@default' in result
+        assert len(result['@default']) == 0
+
+        # Check that '_:g4' graph exists and contains the quad
+        assert '_:g4' in result
+        assert len(result['_:g4']) == 1
+
+    def test_to_legacy_dataset_correctly_maps_default_graph(self):
+        """Ensure graph key is correctly derived '@default' for None or default graph."""
+        self.dataset.add(
+            (URIRef('s1'), URIRef('p2'), Literal('o3'), DATASET_DEFAULT_GRAPH_ID)
+        )
+        self.dataset.add((URIRef('s2'), URIRef('p2'), Literal('o3'), None))
+        print(list(self.dataset.quads((None, None, None, None))))
+        result = to_legacy_dataset(self.dataset)
+
+        assert len(result.keys()) == 1
+        assert '@default' in result
+        assert (
+            len(result['@default']) == 1
+        )  # Only first quad should be in the @default graph
+
+
+class TestFromLegacyDataset:
+    """A comprehensive class-based test suite for `from_legacy_dataset`, split into granular tests."""
+
+    def test_from_legacy_dataset_restores_default_graph(self):
+        """Ensure from_legacy_dataset correctly reconstructs the default graph."""
+        legacy_data = {
+            '@default': [
+                {
+                    'subject': {'type': 'blank node', 'value': '_:s1'},
+                    'predicate': {'type': 'IRI', 'value': 'p1'},
+                    'object': {'type': 'literal', 'value': 'o1'},
+                }
+            ]
+        }
+
+        restored_dataset = from_legacy_dataset(legacy_data)
+
+        for quad in restored_dataset.quads((None, None, None, None)):
+            s, p, o, g = quad
+            assert g == DATASET_DEFAULT_GRAPH_ID
+            assert isinstance(s, BNode)
+            assert str(s) == 's1'
+
+    @pytest.mark.parametrize(
+        "legacy_data",
+        [
+            {
+                'http://example.org': [
+                    {
+                        'subject': {'type': 'blank node', 'value': '_:s1'},
+                        'predicate': {'type': 'IRI', 'value': 'p1'},
+                        'object': {'type': 'literal', 'value': 'o1'},
+                    }
+                ]
+            },
+            {
+                '_:g2': [
+                    {
+                        'subject': {'type': 'blank node', 'value': '_:s2'},
+                        'predicate': {'type': 'blank node', 'value': '_:p4'},
+                        'object': {'type': 'literal', 'value': 'o2'},
+                    }
+                ]
+            },
+        ],
+    )
+    def test_from_legacy_dataset_restores_blank_subject(self, legacy_data):
+        """Ensure from_legacy_dataset correctly reconstructs a blank node subject."""
+        restored_dataset = from_legacy_dataset(legacy_data)
+
+        for quad in restored_dataset.quads((None, None, None, None)):
+            s, p, o, g = quad
+            if isinstance(s, BNode):
+                assert not s.startswith('_:')
+                assert (
+                    str(s)
+                    == legacy_data['_:' + str(g) if isinstance(g, BNode) else str(g)][
+                        0
+                    ]['subject']['value'][2:]
+                )
+
+    @pytest.mark.parametrize(
+        "legacy_data",
+        [
+            {
+                '@default': [
+                    {
+                        'subject': {'type': 'IRI', 'value': 's1'},
+                        'predicate': {'type': 'blank node', 'value': '_:p2'},
+                        'object': {'type': 'literal', 'value': 'o3'},
+                    }
+                ]
+            }
+        ],
+    )
+    def test_from_legacy_dataset_restores_blank_predicate(self, legacy_data):
+        """Ensure from_legacy_dataset correctly reconstructs a blank node predicate."""
+        restored_dataset = from_legacy_dataset(legacy_data)
+
+        for quad in restored_dataset.quads((None, None, None, None)):
+            s, p, o, g = quad
+            if isinstance(p, BNode):
+                assert not str(p).startswith('_:')
+                assert str(p) == legacy_data['@default'][0]['predicate']['value'][2:]
+
+    @pytest.mark.parametrize(
+        "legacy_data",
+        [
+            {
+                '@default': [
+                    {
+                        'subject': {'type': 'IRI', 'value': 's1'},
+                        'predicate': {'type': 'IRI', 'value': 'p2'},
+                        'object': {'type': 'literal', 'value': 'o3', 'language': 'en'},
+                    }
+                ]
+            }
+        ],
+    )
+    def test_from_legacy_dataset_restores_literal_with_language(self, legacy_data):
+        """Ensure from_legacy_dataset correctly restores a literal with language."""
+        restored_dataset = from_legacy_dataset(legacy_data)
+
+        for quad in restored_dataset.quads((None, None, None, None)):
+            s, p, o, g = quad
+            assert o.language == legacy_data['@default'][0]['object']['language']
+
+    @pytest.mark.parametrize(
+        "legacy_data",
+        [
+            {
+                '@default': [
+                    {
+                        'subject': {'type': 'IRI', 'value': 's1'},
+                        'predicate': {'type': 'IRI', 'value': 'p2'},
+                        'object': {
+                            'type': 'literal',
+                            'value': 'o3',
+                            'datatype': 'http://example.org/float',
+                        },
+                    }
+                ]
+            }
+        ],
+    )
+    def test_from_legacy_dataset_restores_literal_with_datatype(self, legacy_data):
+        """Ensure from_legacy_dataset correctly restores a literal with datatype."""
+        restored_dataset = from_legacy_dataset(legacy_data)
+        quads = list(restored_dataset.quads((None, None, None, None)))
+
+        for quad in quads:
+            s, p, o, g = quad
+            if isinstance(o, Literal) and hasattr(o, 'datatype'):
+                assert (
+                    str(o.datatype) == legacy_data['@default'][0]['object']['datatype']
+                )
+
+    def test_from_legacy_dataset_invalid_graph_raises_value_error(self):
+        """Ensure from_legacy_dataset raises ValueError when given invalid graph name."""
+        with pytest.raises(ValueError, match="Illegal graph name: None"):
+            from_legacy_dataset(
+                {
+                    None: [
+                        {
+                            'subject': {'type': 'IRI', 'value': 's1'},
+                            'predicate': {'type': 'IRI', 'value': 'p2'},
+                            'object': {
+                                'type': 'literal',
+                                'value': 'o3',
+                                'datatype': 'http://example.org/float',
+                            },
+                        }
+                    ]
+                }
+            )
+
+    def test_from_legacy_dataset_incomplete_quad_raises_value_error(self):
+        """Ensure from_legacy_dataset raises ValueError when given invalid input (e.g., missing structure)."""
+        with pytest.raises(ValueError, match="Illegal quad structure"):
+            from_legacy_dataset({"@default": [{"subject": {'type': 'IRI', 'value': 's1'}}]})
+
+    def test_from_legacy_dataset_invalid_quad_term_raises_value_error(self):
+        """Ensure from_legacy_dataset raises ValueError when given invalid input (e.g., missing structure)."""
+        with pytest.raises(ValueError, match="Illegal quad structure"):
+            from_legacy_dataset(
+                {
+                    "@default": [
+                        {
+                            'subject': "bad",
+                            'predicate': {'type': 'IRI', 'value': 'p2'},
+                            'object': {
+                                'type': 'literal',
+                                'value': 'o3',
+                                'datatype': 'http://example.org/float',
+                            },
+                        }
+                    ]
+                }
+            )


### PR DESCRIPTION
This PR is a rather big one. It fully implements URDNA2015, URDNA2012 and RDFC10 and has complete test-suite coverage on these algorithms (with the exception of the one on poisonous datasets, but more about that later). It 'fixes' #220 

Some general remarks before I dive into the details:
- I went back and forth on how approach this: move the canon stuff to a new repo first, or fix the problems first. I sided with the latter as the test harness is already in place and the code is too tangled to not break everything.
- This **introduces rdflib into PyLD**, but limited to the normalization/canonicalization `canon.py`. This made the code much much cleaner, but ironically didn't fix what I introduced it for: nquad serialization. The relevant methods are copied over from rdflib until I can turn them into PRs for rdflib. 
- I added some functions to transform the legacy RDF.JS dataset structure in an `rdflib.Dataset` and back. This should ensure backwards-compatibility on some methods such as `jsonld.normalization()` and `URDNA2015.main()`.
- While switching to rdflib introduces significant changes, I tried to **change as little as possible otherwise**. Optimizing the algorithm implementations can be done later.

Overview of the changes:
- added `rdflib` dependency in all relevant config and code files.
- the change to `rdflib` mostly changed
  - RDF term type checking (e.g., checking is something is a bnode)
  - looping over triples/quads
  - serialization
  - constructing RDF terms (custom deepcopy is no longer needed)
- `util.py`
  - added the functions `from_legacy_dataset()` and `to_legacy_dataset()` to easily go from an `rdflib.Dataset` to an RDFJS-like `dict` wherever needed. 
  - Also added unittests in `tests/test_util.py` for these functions. We might want to move more general-purpose methods to this file.
- `canon.py`:
  - the main logic was moved to `URDNA2015._canonicalize(self, dataset: Dataset)` while handling input and output remained in `URDNA2015.main()`. The latter now does the nquads parsing instead of `JsonLdProcessor.normalize()`, so all parsing and serialization is handled by the same class. 
  - the method `URDNA2015._canonicalize(self, dataset: Dataset)` accepts an `rdflib.Dataset` and returns a tuple with 
    - the canonicalized result as a nquads `str` and 
    - the blank node identifier map as `dict`.
  - The method `URDNA2015 .main(self, dataset: str | dict | Dataset, options)` now accepts a `rdflib.Dataset` object in addition to an nquads `str` or the original RDFJS-like`dict`. It returns 
    - a `str`: the serialized nquads result, or 
    - a `dict`: the result as RDFJS-like dataset or the blank node identifier map when the new parameter `outputMap` is `True`.
  - the hashing algorithm is now an class attribute `URDNA2015.hash_algorithm` so it easily configurable (required for RDFC1.0)
  - the `permutations()` function now uses `itertools.permutations` instead of a custom implementation.
  - replacements for rdflib's `_nq_row` and `_quoteLiteral`, which should eventually move to a fix for rdflib's nquads serializer.
- `tests/runtests.py`
  - (re-)enabled all skipped URDNA2015, URDNA2012
  -  Added the RDFC10 tests
    - added support for testing blank-node identifier maps. If the result of a test is a dict and the expected value is a string, the expected value is now parsed as JSON.
    - added support for testing with different hashing algorithms
    - !! I did not include test 74c on dataset poisoning because I'm not sure how to handle that yet. We need to discuss possible guardrails  first before continuing on this.

It's possible that we move this code out before ever merging, but at least it can be easily tested. That said, when importing this functionality as an external library, we include rdflib anyway. It therefore makes sense to continue replacing the RDFJS-like data structures elsewhere in the code, essentially making it fully rdflib compliant and dependent.

Since this involves RDFLib: @nicholascar, anyone who can maybe have a look at this? Also @davidlehn @BigBlueHat @anatoly-scherbakov 