### PR TITLE
fix: prevent scoped context cache pollution during context processing

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3362,6 +3362,18 @@ class JsonLdProcessor:
                                 code='invalid scoped context',
                             ) from cause
 
+            # Regenerate _uuid after all term definitions are created.
+            # During the loop above, scoped contexts in term definitions are
+            # pre-validated via _process_context(rval, ...), which caches the
+            # processed result keyed by rval['_uuid']. At that point rval has
+            # only a partial set of mappings (terms processed so far). When
+            # the returned context is later used during expansion and its
+            # scoped contexts are processed, the same _uuid would produce a
+            # stale cache hit with incomplete mappings. Assigning a fresh
+            # _uuid ensures expansion-time lookups miss the pre-validation
+            # cache and process scoped contexts against the complete context.
+            rval['_uuid'] = str(uuid.uuid1())
+
             # cache processed result (only Python >= 3.6)
             # and give the context a unique identifier
             rval = freeze(rval)

--- a/tests/test_scoped_context_cache.py
+++ b/tests/test_scoped_context_cache.py
@@ -1,0 +1,142 @@
+"""
+Regression test for scoped context cache pollution during context processing.
+
+When a JSON-LD context has multiple terms that share the same scoped @context
+(e.g., enum-typed properties using @type: @vocab with a scoped @vocab), the
+pre-validation of scoped contexts during _process_context would cache the
+processed result keyed by rval['_uuid']. Since rval is mutated (mappings added)
+during the loop, later expansion-time lookups of the same scoped context would
+get a stale cache hit with incomplete mappings, causing @type coercion to fail.
+
+The fix regenerates rval['_uuid'] after all term definitions are created,
+ensuring expansion-time lookups miss the pre-validation cache.
+"""
+from pyld import jsonld
+
+
+NS = "https://example.org/vocab/"
+
+# A context with multiple terms sharing the same scoped @context.
+# This triggers the bug: the first scoped context pre-validation caches
+# a result with partial mappings, and subsequent expansion-time lookups
+# get a stale cache hit.
+SHARED_SCOPED_CTX = {
+    "@vocab": NS,
+    "text": "http://www.w3.org/2004/02/skos/core#notation",
+    "description": "http://www.w3.org/2004/02/skos/core#prefLabel",
+    "meaning": "@id",
+}
+
+
+def _make_context(num_terms):
+    """Build a context with `num_terms` @type:@vocab terms sharing a scoped context."""
+    ctx = {"ex": NS}
+    for i in range(num_terms):
+        ctx[f"EnumProp{i}"] = {
+            "@id": f"ex:EnumProp{i}",
+            "@type": "@vocab",
+            "@context": dict(SHARED_SCOPED_CTX),
+        }
+    # Add some plain string terms to increase context size
+    for i in range(80):
+        ctx[f"prop{i}"] = f"ex:prop{i}"
+    return ctx
+
+
+def test_single_vocab_term_expands_correctly():
+    """Single @type:@vocab term should expand bare string to @id."""
+    ctx = {
+        "ex": NS,
+        "Color": {
+            "@id": "ex:Color",
+            "@type": "@vocab",
+            "@context": {"@vocab": NS},
+        },
+    }
+    doc = {"@context": ctx, "Color": "Red"}
+    result = jsonld.expand(doc)
+    assert result[0][f"{NS}Color"] == [{"@id": f"{NS}Red"}]
+
+
+def test_many_shared_scoped_contexts_expand_correctly():
+    """Multiple @type:@vocab terms with identical scoped contexts should all expand."""
+    ctx = _make_context(num_terms=30)
+    doc = {"@context": ctx}
+    # Set a value for each enum property
+    for i in range(30):
+        doc[f"EnumProp{i}"] = f"Value{i}"
+
+    result = jsonld.expand(doc)
+    expanded = result[0]
+
+    for i in range(30):
+        prop_iri = f"{NS}EnumProp{i}"
+        assert prop_iri in expanded, f"EnumProp{i} not in expanded result"
+        assert expanded[prop_iri] == [{"@id": f"{NS}Value{i}"}], (
+            f"EnumProp{i} did not expand to @id"
+        )
+
+
+def test_last_vocab_term_expands_with_large_context():
+    """The LAST @type:@vocab term in a large context must also expand correctly.
+
+    This is the most likely to fail because all prior scoped context
+    pre-validations have already populated the cache.
+    """
+    ctx = _make_context(num_terms=27)
+    # Only test the last term
+    doc = {"@context": ctx, "EnumProp26": "TestValue"}
+    result = jsonld.expand(doc)
+    assert result[0][f"{NS}EnumProp26"] == [{"@id": f"{NS}TestValue"}]
+
+
+def test_structured_value_still_works_with_scoped_context():
+    """Structured values (objects) should still use the scoped context mappings."""
+    ctx = _make_context(num_terms=10)
+    doc = {
+        "@context": ctx,
+        "EnumProp5": {
+            "text": "MyLabel",
+            "description": "A description",
+            "meaning": f"{NS}SomeValue",
+        },
+    }
+    result = jsonld.expand(doc)
+    prop_val = result[0][f"{NS}EnumProp5"][0]
+    # text -> skos:notation
+    assert "http://www.w3.org/2004/02/skos/core#notation" in prop_val
+    # meaning -> @id
+    assert "@id" in prop_val
+
+
+def test_mixed_plain_and_vocab_terms():
+    """Contexts with both plain and @type:@vocab terms should work correctly."""
+    ctx = {
+        "ex": NS,
+        "name": "ex:name",
+        "Color": {
+            "@id": "ex:Color",
+            "@type": "@vocab",
+            "@context": {"@vocab": NS},
+        },
+        "Shape": {
+            "@id": "ex:Shape",
+            "@type": "@vocab",
+            "@context": {"@vocab": NS},
+        },
+    }
+    # Add many plain terms to make context large enough to trigger caching
+    for i in range(100):
+        ctx[f"field{i}"] = f"ex:field{i}"
+
+    doc = {
+        "@context": ctx,
+        "name": "test",
+        "Color": "Blue",
+        "Shape": "Circle",
+    }
+    result = jsonld.expand(doc)
+    expanded = result[0]
+    assert expanded[f"{NS}Color"] == [{"@id": f"{NS}Blue"}]
+    assert expanded[f"{NS}Shape"] == [{"@id": f"{NS}Circle"}]
+    assert expanded[f"{NS}name"] == [{"@value": "test"}]

--- a/tests/test_scoped_context_cache.py
+++ b/tests/test_scoped_context_cache.py
@@ -13,7 +13,6 @@ ensuring expansion-time lookups miss the pre-validation cache.
 """
 from pyld import jsonld
 
-
 NS = "https://example.org/vocab/"
 
 # A context with multiple terms sharing the same scoped @context.


### PR DESCRIPTION
## Summary

Fixes a bug where `@type: @vocab` coercion silently fails when a JSON-LD context contains **multiple terms sharing the same scoped `@context`** -- a pattern that arises naturally with enum-typed properties.

This is the same underlying issue reported in #201, but with a **minimal, targeted fix** (1 line of production code + comment) instead of threading `active_property` paths through the entire processing stack.

## Bug Description

### Symptom

Given a context with multiple `@type: @vocab` terms that share an identical scoped `@context`:

```json
{
  "Color": {
    "@id": "ex:Color",
    "@type": "@vocab",
    "@context": { "@vocab": "https://example.org/vocab/" }
  },
  "Shape": {
    "@id": "ex:Shape",
    "@type": "@vocab",
    "@context": { "@vocab": "https://example.org/vocab/" }
  }
}
```

Expansion of the **first** term works correctly, but **subsequent** terms produce `{"@value": "Circle"}` (plain literal) instead of `{"@id": "https://example.org/vocab/Circle"}` (IRI).

### Root Cause

During context processing in `_process_context()` (line ~3326), the method iterates over all terms in the context, calling `_create_term_definition()` for each. After each term definition, if the term has a scoped `@context`, it is **pre-validated** by calling `_process_context(rval, key_ctx, ...)` recursively (lines 3337-3363). The result of this validation is discarded, but it has a **critical side effect**: it populates the `ResolvedContext` cache.

The cache key is `rval['_uuid']`, which is assigned once after cloning (line 3321) and **never changes** during the entire term definition loop. At the time the first scoped context is pre-validated, `rval` has only a **partial** set of term mappings (only terms processed so far). The processed result -- with incomplete mappings -- is cached.

Later, when the fully-built context is used during **expansion** and the same scoped context needs to be processed (line 2605), `_process_context()` finds a **stale cache hit** (same `_uuid`, same canonical scoped context) and returns the incomplete result. This causes `get_context_value(active_ctx, term, '@type')` to return `None` instead of `'@vocab'`, so the value falls through to the `@value` branch instead of the `@id` branch in `_expand_value()`.

### Trace Evidence

Instrumented trace showing the cache pollution:

```
# During context processing -- pre-validation caches partial result:
_process_context depth=1 ctx=dict(4 keys) active_uuid=d3085059
  result mappings count: 12    <-- only 12 mappings (partial!)

# During expansion -- stale cache hit returns partial result:
_process_context depth=0 ctx=dict(4 keys) active_uuid=d3085059
  CACHE HIT => mappings=12 has_DrivableAreaType=False    <-- BUG!

# Result: @value instead of @id
{"@value": "RoadTypeMotorway"}    <-- should be {"@id": "...RoadTypeMotorway"}
```

## Fix

**One line of production code**: After the term definition loop completes (all mappings are in `rval`), regenerate `rval['_uuid']` before freezing:

```python
rval['_uuid'] = str(uuid.uuid1())
```

This ensures that expansion-time lookups of scoped contexts use a `_uuid` that was never used during pre-validation, so they miss the stale cache and process the scoped context against the **complete** active context.

### Why This Approach

As @dlongley noted in [#201 (comment)](https://github.com/digitalbazaar/pyld/pull/201#issuecomment-3352766096):

> the python version does not generate a new `_uuid` property when cloning an active context for modification [...] Which seems like the most natural place to do this in order for it to be a "unique object identifier", similar to using the object reference itself in jsonld.js

The broader suggestion of adding `_uuid` to `_clone_active_context()` is sound for general correctness, but **alone it does not fix this specific bug** -- the outer `rval` keeps its clone-time `_uuid` throughout the loop and into the final freeze, so the pre-validation cache entries would still match. The targeted regeneration after the loop is necessary.

## Test Plan

### New regression tests (5 tests in `tests/test_scoped_context_cache.py`):

| Test | Description |
|------|-------------|
| `test_single_vocab_term_expands_correctly` | Baseline: single `@type: @vocab` term (always worked) |
| `test_many_shared_scoped_contexts_expand_correctly` | 30 enum terms with shared scoped context -- all must expand to `@id` |
| `test_last_vocab_term_expands_with_large_context` | Last of 27 enum terms in large context (most likely to fail due to cache) |
| `test_structured_value_still_works_with_scoped_context` | Object values still use scoped context mappings (`text`, `description`, `meaning`) |
| `test_mixed_plain_and_vocab_terms` | Mix of plain string terms and `@type: @vocab` terms in 100+ key context |

### Without fix: 3 of 5 fail. With fix: all 5 pass.

### Existing test suites -- zero regressions:

| Suite | Result |
|-------|--------|
| W3C JSON-LD API (`specifications/json-ld-api/tests/`) | **1277 passed**, 41 skipped |
| W3C JSON-LD Framing (`specifications/json-ld-framing/tests/`) | **92 passed**, 2 skipped |
| RDF Normalization (`specifications/normalization/tests/`) | **121 passed**, 2 skipped |
| pyld unit tests (`tests/`) | **164 passed** |

## Real-World Impact

This bug affects any JSON-LD context generated from schemas with enum-typed properties -- a common pattern in ontology management. We discovered it while implementing `@type: @vocab` context generation for [LinkML](https://github.com/linkml/linkml) enum slots ([linkml/linkml#2497](https://github.com/linkml/linkml/issues/2497)), where 27 enum properties in an OpenLABEL ontology all share identical scoped contexts. The bug caused all enum values to expand as plain literals instead of vocabulary IRIs, silently breaking SHACL validation downstream.

The `rdflib` JSON-LD implementation handles the same contexts correctly, confirming the context structure is valid per JSON-LD 1.1 section 4.2.3 (Type Coercion) and section 4.1.8 (Scoped Contexts).

## Related

- #201 -- Same bug, different fix approach (threading `active_property` paths as cache keys)
- digitalbazaar/jsonld.js -- Not affected (uses object references as cache keys via WeakMap)
