### PR TITLE
Add FrozenDocumentLoader for offline / vetted JSON-LD contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # pyld ChangeLog
 
+## 3.1.0 - unreleased
+
+### Added
+- `pyld.DocumentLoader` abstract base class for class-based document loaders,
+  with a `RemoteDocument` `TypedDict` describing the expected return shape.
+- `pyld.FrozenDocumentLoader`: a class-based loader that serves only URLs in
+  its `documents` allowlist and refuses everything else with
+  `JsonLdError(code='loading document failed')`. Instantiating with no
+  arguments serves the curated `pyld.BUNDLED_CONTEXTS` set; instantiating
+  with `dict(BUNDLED_CONTEXTS, **extras)` extends the bundle. Suitable for
+  air-gapped, reproducible-build, and security-hardened deployments.
+- `pyld.BUNDLED_CONTEXTS`: curated mapping of high-traffic public W3C / W3ID
+  JSON-LD contexts (ActivityStreams, DID v1, VC v1/v2, Linked Data Security
+  v1/v2, Ed25519-2020, JWS-2020) to vendored on-disk copies. Refresh with
+  `make download-bundled-contexts`.
+
 ## 3.0.0 - 2026-04-02
 
 ### Changed

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst README.txt LICENSE CHANGELOG.md
+recursive-include lib/pyld/documentloader/frozen/bundled *.jsonld

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test upgrade-submodules
+.PHONY: install test upgrade-submodules download-bundled-contexts
 
 install:
 	pip install -e .
@@ -8,6 +8,9 @@ test:
 
 upgrade-submodules:
 	git submodule update --remote --init --recursive
+
+download-bundled-contexts:
+	python scripts/download_contexts.py
 
 RUFF_TARGET = lib/pyld/*.py tests/*.py
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,35 @@ If Requests_ is not available, the loader is set to aiohttp_. The fallback
 document loader is a dummy document loader that raises an exception on every
 invocation.
 
+Frozen Document Loader
+~~~~~~~~~~~~~~~~~~~~~~
+
+For air-gapped runs, reproducible builds, and security-hardened deployments
+that must not perform any remote context fetches at all, PyLD ships
+``FrozenDocumentLoader``: a class-based loader that serves only the URLs in
+its ``documents`` allowlist and refuses everything else with
+``JsonLdError(code='loading document failed')``.
+
+Instantiating with no arguments serves the curated ``BUNDLED_CONTEXTS`` set
+(ActivityStreams, DID v1, Verifiable Credentials v1 and v2, Linked Data
+Security v1/v2, Ed25519-2020, and JWS-2020). To extend the bundle with
+additional pre-vetted contexts, pass a merged mapping:
+
+.. code-block:: Python
+
+    from pyld import jsonld, FrozenDocumentLoader, BUNDLED_CONTEXTS
+
+    loader = FrozenDocumentLoader(documents=dict(
+        BUNDLED_CONTEXTS,
+        **{'https://example.com/my-ctx': Path('contexts/my-ctx.jsonld')},
+    ))
+    jsonld.expand(doc, options={'documentLoader': loader})
+
+This honors the W3C *JSON-LD Best Practices* recommendation that clients
+SHOULD attempt to use a locally cached version of contexts (see
+`§ Cache JSON-LD Contexts <https://w3c.github.io/json-ld-bp/#cache-json-ld-contexts>`_).
+Refresh the bundled copies with ``make download-bundled-contexts``.
+
 Handling ignored properties during JSON-LD expansion
 ----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,13 @@ API Reference
 .. autofunction:: frame
 .. autofunction:: normalize
 
+.. module:: pyld
+.. autoclass:: DocumentLoader
+   :members:
+.. autoclass:: FrozenDocumentLoader
+   :members:
+.. autodata:: BUNDLED_CONTEXTS
+
 Indices and tables
 ------------------
 

--- a/lib/pyld/__init__.py
+++ b/lib/pyld/__init__.py
@@ -2,5 +2,14 @@
 
 from . import jsonld
 from .context_resolver import ContextResolver
+from .documentloader.base import DocumentLoader, RemoteDocument
+from .documentloader.frozen import BUNDLED_CONTEXTS, FrozenDocumentLoader
 
-__all__ = ['jsonld', 'ContextResolver']
+__all__ = [
+    'BUNDLED_CONTEXTS',
+    'ContextResolver',
+    'DocumentLoader',
+    'FrozenDocumentLoader',
+    'RemoteDocument',
+    'jsonld',
+]

--- a/lib/pyld/documentloader/base.py
+++ b/lib/pyld/documentloader/base.py
@@ -1,0 +1,44 @@
+"""
+Abstract base class for class-based JSON-LD document loaders.
+
+.. module:: jsonld.documentloader.base
+  :synopsis: DocumentLoader abstract base class
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, TypedDict
+
+
+class RemoteDocument(TypedDict):
+    """Shape returned by a JSON-LD document loader.
+
+    Mirrors the *RemoteDocument* structure defined in the W3C JSON-LD 1.1 API
+    (https://www.w3.org/TR/json-ld11-api/#remotedocument).
+    """
+
+    contentType: str
+    contextUrl: str | None
+    documentUrl: str
+    document: Any
+
+
+class DocumentLoader(ABC):
+    """Abstract base class for class-based JSON-LD document loaders.
+
+    Concrete subclasses implement :meth:`__call__` to fetch a document for a
+    given URL and return a :class:`RemoteDocument`.
+
+    Existing function-based loaders (:func:`pyld.jsonld.requests_document_loader`,
+    :func:`pyld.jsonld.aiohttp_document_loader`) remain valid: pyld's loader
+    contract is "any callable with the right signature". This ABC is for new
+    class-based loaders only.
+    """
+
+    @abstractmethod
+    def __call__(self, url: str, options: dict) -> RemoteDocument:
+        """Retrieve the JSON-LD document at ``url``.
+
+        :param url: the URL to retrieve.
+        :param options: loader options (e.g. ``headers``).
+        :return: a :class:`RemoteDocument`.
+        """

--- a/lib/pyld/documentloader/frozen/__init__.py
+++ b/lib/pyld/documentloader/frozen/__init__.py
@@ -1,0 +1,85 @@
+"""
+Frozen JSON-LD document loader.
+
+A document loader that serves *only* the URLs in its ``documents`` allowlist
+and refuses everything else with :class:`pyld.jsonld.JsonLdError`. Suitable for
+secure / air-gapped / privacy-sensitive deployments and for honoring the
+guidance in the W3C *JSON-LD Best Practices* note that clients SHOULD attempt
+to use a locally cached version of contexts (§ Cache JSON-LD Contexts,
+https://w3c.github.io/json-ld-bp/#cache-json-ld-contexts).
+
+This module also defines :data:`BUNDLED_CONTEXTS`, a curated mapping of
+high-traffic public W3C / W3ID JSON-LD context URLs to vendored on-disk copies
+shipped with the package. See ``scripts/download_contexts.py`` for how the
+files in ``bundled/`` are refreshed.
+
+.. module:: jsonld.documentloader.frozen
+  :synopsis: FrozenDocumentLoader and BUNDLED_CONTEXTS
+"""
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from pyld.documentloader.base import DocumentLoader, RemoteDocument
+from pyld.jsonld import JsonLdError
+
+_BUNDLED_DIR = Path(__file__).parent / 'bundled'
+
+
+BUNDLED_CONTEXTS: Mapping[str, Path] = {
+    'https://www.w3.org/ns/activitystreams': _BUNDLED_DIR / 'activitystreams.jsonld',
+    'https://www.w3.org/ns/did/v1': _BUNDLED_DIR / 'did-v1.jsonld',
+    'https://www.w3.org/2018/credentials/v1': _BUNDLED_DIR / 'credentials-v1.jsonld',
+    'https://www.w3.org/ns/credentials/v2': _BUNDLED_DIR / 'credentials-v2.jsonld',
+    'https://w3id.org/security/v1': _BUNDLED_DIR / 'security-v1.jsonld',
+    'https://w3id.org/security/v2': _BUNDLED_DIR / 'security-v2.jsonld',
+    'https://w3id.org/security/suites/ed25519-2020/v1': _BUNDLED_DIR
+    / 'security-ed25519-2020-v1.jsonld',
+    'https://w3id.org/security/suites/jws-2020/v1': _BUNDLED_DIR
+    / 'security-jws-2020-v1.jsonld',
+}
+
+
+@dataclass
+class FrozenDocumentLoader(DocumentLoader):
+    """Document loader that serves only a sealed allowlist of URLs.
+
+    ``documents`` maps each allowed URL to either a parsed JSON-LD ``dict`` or
+    a :class:`pathlib.Path` pointing to a JSON file on disk. Path entries are
+    read and parsed lazily on first request, then cached in place so subsequent
+    calls skip the file read. Any URL not present in the mapping raises
+    :class:`pyld.jsonld.JsonLdError` with code ``'loading document failed'``.
+
+    With no arguments, a ``FrozenDocumentLoader`` serves the curated
+    :data:`BUNDLED_CONTEXTS` set. To extend rather than replace the bundle::
+
+        FrozenDocumentLoader(documents=dict(BUNDLED_CONTEXTS, **extras))
+    """
+
+    documents: dict = field(default_factory=lambda: dict(BUNDLED_CONTEXTS))
+
+    def __post_init__(self) -> None:
+        # Take ownership of the mapping so we can cache parsed Paths in place
+        # without mutating the caller's dict.
+        self.documents = dict(self.documents)
+
+    def __call__(self, url: str, options: dict) -> RemoteDocument:
+        if url not in self.documents:
+            raise JsonLdError(
+                'Refusing to load document outside the allowed set.',
+                'jsonld.LoadDocumentError',
+                {'url': url},
+                code='loading document failed',
+            )
+        value: dict | Path = self.documents[url]
+        if isinstance(value, Path):
+            value = json.loads(value.read_text(encoding='utf-8'))
+            self.documents[url] = value
+        return {
+            'contentType': 'application/ld+json',
+            'contextUrl': None,
+            'documentUrl': url,
+            'document': value,
+        }

--- a/lib/pyld/documentloader/frozen/__init__.py
+++ b/lib/pyld/documentloader/frozen/__init__.py
@@ -19,7 +19,6 @@ files in ``bundled/`` are refreshed.
 
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass, field
 from pathlib import Path
 
 from pyld.documentloader.base import DocumentLoader, RemoteDocument
@@ -42,7 +41,6 @@ BUNDLED_CONTEXTS: Mapping[str, Path] = {
 }
 
 
-@dataclass
 class FrozenDocumentLoader(DocumentLoader):
     """Document loader that serves only a sealed allowlist of URLs.
 
@@ -58,12 +56,12 @@ class FrozenDocumentLoader(DocumentLoader):
         FrozenDocumentLoader(documents=dict(BUNDLED_CONTEXTS, **extras))
     """
 
-    documents: dict = field(default_factory=lambda: dict(BUNDLED_CONTEXTS))
-
-    def __post_init__(self) -> None:
+    def __init__(self, documents: Mapping[str, dict | Path] | None = None) -> None:
         # Take ownership of the mapping so we can cache parsed Paths in place
         # without mutating the caller's dict.
-        self.documents = dict(self.documents)
+        if documents is None:
+            documents = BUNDLED_CONTEXTS
+        self.documents = dict(documents)
 
     def __call__(self, url: str, options: dict) -> RemoteDocument:
         if url not in self.documents:

--- a/lib/pyld/documentloader/frozen/bundled/activitystreams.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/activitystreams.jsonld
@@ -1,0 +1,379 @@
+{
+  "@context": {
+    "@vocab": "_:",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "as": "https://www.w3.org/ns/activitystreams#",
+    "ldp": "http://www.w3.org/ns/ldp#",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "id": "@id",
+    "type": "@type",
+    "Accept": "as:Accept",
+    "Activity": "as:Activity",
+    "IntransitiveActivity": "as:IntransitiveActivity",
+    "Add": "as:Add",
+    "Announce": "as:Announce",
+    "Application": "as:Application",
+    "Arrive": "as:Arrive",
+    "Article": "as:Article",
+    "Audio": "as:Audio",
+    "Block": "as:Block",
+    "Collection": "as:Collection",
+    "CollectionPage": "as:CollectionPage",
+    "Relationship": "as:Relationship",
+    "Create": "as:Create",
+    "Delete": "as:Delete",
+    "Dislike": "as:Dislike",
+    "Document": "as:Document",
+    "Event": "as:Event",
+    "Follow": "as:Follow",
+    "Flag": "as:Flag",
+    "Group": "as:Group",
+    "Ignore": "as:Ignore",
+    "Image": "as:Image",
+    "Invite": "as:Invite",
+    "Join": "as:Join",
+    "Leave": "as:Leave",
+    "Like": "as:Like",
+    "Link": "as:Link",
+    "Mention": "as:Mention",
+    "Note": "as:Note",
+    "Object": "as:Object",
+    "Offer": "as:Offer",
+    "OrderedCollection": "as:OrderedCollection",
+    "OrderedCollectionPage": "as:OrderedCollectionPage",
+    "Organization": "as:Organization",
+    "Page": "as:Page",
+    "Person": "as:Person",
+    "Place": "as:Place",
+    "Profile": "as:Profile",
+    "Question": "as:Question",
+    "Reject": "as:Reject",
+    "Remove": "as:Remove",
+    "Service": "as:Service",
+    "TentativeAccept": "as:TentativeAccept",
+    "TentativeReject": "as:TentativeReject",
+    "Tombstone": "as:Tombstone",
+    "Undo": "as:Undo",
+    "Update": "as:Update",
+    "Video": "as:Video",
+    "View": "as:View",
+    "Listen": "as:Listen",
+    "Read": "as:Read",
+    "Move": "as:Move",
+    "Travel": "as:Travel",
+    "IsFollowing": "as:IsFollowing",
+    "IsFollowedBy": "as:IsFollowedBy",
+    "IsContact": "as:IsContact",
+    "IsMember": "as:IsMember",
+    "subject": {
+      "@id": "as:subject",
+      "@type": "@id"
+    },
+    "relationship": {
+      "@id": "as:relationship",
+      "@type": "@id"
+    },
+    "actor": {
+      "@id": "as:actor",
+      "@type": "@id"
+    },
+    "attributedTo": {
+      "@id": "as:attributedTo",
+      "@type": "@id"
+    },
+    "attachment": {
+      "@id": "as:attachment",
+      "@type": "@id"
+    },
+    "bcc": {
+      "@id": "as:bcc",
+      "@type": "@id"
+    },
+    "bto": {
+      "@id": "as:bto",
+      "@type": "@id"
+    },
+    "cc": {
+      "@id": "as:cc",
+      "@type": "@id"
+    },
+    "context": {
+      "@id": "as:context",
+      "@type": "@id"
+    },
+    "current": {
+      "@id": "as:current",
+      "@type": "@id"
+    },
+    "first": {
+      "@id": "as:first",
+      "@type": "@id"
+    },
+    "generator": {
+      "@id": "as:generator",
+      "@type": "@id"
+    },
+    "icon": {
+      "@id": "as:icon",
+      "@type": "@id"
+    },
+    "image": {
+      "@id": "as:image",
+      "@type": "@id"
+    },
+    "inReplyTo": {
+      "@id": "as:inReplyTo",
+      "@type": "@id"
+    },
+    "items": {
+      "@id": "as:items",
+      "@type": "@id"
+    },
+    "instrument": {
+      "@id": "as:instrument",
+      "@type": "@id"
+    },
+    "orderedItems": {
+      "@id": "as:items",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "last": {
+      "@id": "as:last",
+      "@type": "@id"
+    },
+    "location": {
+      "@id": "as:location",
+      "@type": "@id"
+    },
+    "next": {
+      "@id": "as:next",
+      "@type": "@id"
+    },
+    "object": {
+      "@id": "as:object",
+      "@type": "@id"
+    },
+    "oneOf": {
+      "@id": "as:oneOf",
+      "@type": "@id"
+    },
+    "anyOf": {
+      "@id": "as:anyOf",
+      "@type": "@id"
+    },
+    "closed": {
+      "@id": "as:closed",
+      "@type": "xsd:dateTime"
+    },
+    "origin": {
+      "@id": "as:origin",
+      "@type": "@id"
+    },
+    "accuracy": {
+      "@id": "as:accuracy",
+      "@type": "xsd:float"
+    },
+    "prev": {
+      "@id": "as:prev",
+      "@type": "@id"
+    },
+    "preview": {
+      "@id": "as:preview",
+      "@type": "@id"
+    },
+    "replies": {
+      "@id": "as:replies",
+      "@type": "@id"
+    },
+    "result": {
+      "@id": "as:result",
+      "@type": "@id"
+    },
+    "audience": {
+      "@id": "as:audience",
+      "@type": "@id"
+    },
+    "partOf": {
+      "@id": "as:partOf",
+      "@type": "@id"
+    },
+    "tag": {
+      "@id": "as:tag",
+      "@type": "@id"
+    },
+    "target": {
+      "@id": "as:target",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "as:to",
+      "@type": "@id"
+    },
+    "url": {
+      "@id": "as:url",
+      "@type": "@id"
+    },
+    "altitude": {
+      "@id": "as:altitude",
+      "@type": "xsd:float"
+    },
+    "content": "as:content",
+    "contentMap": {
+      "@id": "as:content",
+      "@container": "@language"
+    },
+    "name": "as:name",
+    "nameMap": {
+      "@id": "as:name",
+      "@container": "@language"
+    },
+    "duration": {
+      "@id": "as:duration",
+      "@type": "xsd:duration"
+    },
+    "endTime": {
+      "@id": "as:endTime",
+      "@type": "xsd:dateTime"
+    },
+    "height": {
+      "@id": "as:height",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "href": {
+      "@id": "as:href",
+      "@type": "@id"
+    },
+    "hreflang": "as:hreflang",
+    "latitude": {
+      "@id": "as:latitude",
+      "@type": "xsd:float"
+    },
+    "longitude": {
+      "@id": "as:longitude",
+      "@type": "xsd:float"
+    },
+    "mediaType": "as:mediaType",
+    "published": {
+      "@id": "as:published",
+      "@type": "xsd:dateTime"
+    },
+    "radius": {
+      "@id": "as:radius",
+      "@type": "xsd:float"
+    },
+    "rel": "as:rel",
+    "startIndex": {
+      "@id": "as:startIndex",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "startTime": {
+      "@id": "as:startTime",
+      "@type": "xsd:dateTime"
+    },
+    "summary": "as:summary",
+    "summaryMap": {
+      "@id": "as:summary",
+      "@container": "@language"
+    },
+    "totalItems": {
+      "@id": "as:totalItems",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "units": "as:units",
+    "updated": {
+      "@id": "as:updated",
+      "@type": "xsd:dateTime"
+    },
+    "width": {
+      "@id": "as:width",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "describes": {
+      "@id": "as:describes",
+      "@type": "@id"
+    },
+    "formerType": {
+      "@id": "as:formerType",
+      "@type": "@id"
+    },
+    "deleted": {
+      "@id": "as:deleted",
+      "@type": "xsd:dateTime"
+    },
+    "inbox": {
+      "@id": "ldp:inbox",
+      "@type": "@id"
+    },
+    "outbox": {
+      "@id": "as:outbox",
+      "@type": "@id"
+    },
+    "following": {
+      "@id": "as:following",
+      "@type": "@id"
+    },
+    "followers": {
+      "@id": "as:followers",
+      "@type": "@id"
+    },
+    "streams": {
+      "@id": "as:streams",
+      "@type": "@id"
+    },
+    "preferredUsername": "as:preferredUsername",
+    "endpoints": {
+      "@id": "as:endpoints",
+      "@type": "@id"
+    },
+    "uploadMedia": {
+      "@id": "as:uploadMedia",
+      "@type": "@id"
+    },
+    "proxyUrl": {
+      "@id": "as:proxyUrl",
+      "@type": "@id"
+    },
+    "liked": {
+      "@id": "as:liked",
+      "@type": "@id"
+    },
+    "oauthAuthorizationEndpoint": {
+      "@id": "as:oauthAuthorizationEndpoint",
+      "@type": "@id"
+    },
+    "oauthTokenEndpoint": {
+      "@id": "as:oauthTokenEndpoint",
+      "@type": "@id"
+    },
+    "provideClientKey": {
+      "@id": "as:provideClientKey",
+      "@type": "@id"
+    },
+    "signClientKey": {
+      "@id": "as:signClientKey",
+      "@type": "@id"
+    },
+    "sharedInbox": {
+      "@id": "as:sharedInbox",
+      "@type": "@id"
+    },
+    "Public": {
+      "@id": "as:Public",
+      "@type": "@id"
+    },
+    "source": "as:source",
+    "likes": {
+      "@id": "as:likes",
+      "@type": "@id"
+    },
+    "shares": {
+      "@id": "as:shares",
+      "@type": "@id"
+    },
+    "alsoKnownAs": {
+      "@id": "as:alsoKnownAs",
+      "@type": "@id"
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/credentials-v1.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/credentials-v1.jsonld
@@ -1,0 +1,315 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "cred": "https://www.w3.org/2018/credentials#",
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
+        "credentialStatus": {
+          "@id": "cred:credentialStatus",
+          "@type": "@id"
+        },
+        "credentialSubject": {
+          "@id": "cred:credentialSubject",
+          "@type": "@id"
+        },
+        "evidence": {
+          "@id": "cred:evidence",
+          "@type": "@id"
+        },
+        "expirationDate": {
+          "@id": "cred:expirationDate",
+          "@type": "xsd:dateTime"
+        },
+        "holder": {
+          "@id": "cred:holder",
+          "@type": "@id"
+        },
+        "issued": {
+          "@id": "cred:issued",
+          "@type": "xsd:dateTime"
+        },
+        "issuer": {
+          "@id": "cred:issuer",
+          "@type": "@id"
+        },
+        "issuanceDate": {
+          "@id": "cred:issuanceDate",
+          "@type": "xsd:dateTime"
+        },
+        "proof": {
+          "@id": "sec:proof",
+          "@type": "@id",
+          "@container": "@graph"
+        },
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "cred": "https://www.w3.org/2018/credentials#",
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
+        "termsOfUse": {
+          "@id": "cred:termsOfUse",
+          "@type": "@id"
+        },
+        "validFrom": {
+          "@id": "cred:validFrom",
+          "@type": "xsd:dateTime"
+        },
+        "validUntil": {
+          "@id": "cred:validUntil",
+          "@type": "xsd:dateTime"
+        }
+      }
+    },
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+        "holder": {
+          "@id": "cred:holder",
+          "@type": "@id"
+        },
+        "proof": {
+          "@id": "sec:proof",
+          "@type": "@id",
+          "@container": "@graph"
+        },
+        "verifiableCredential": {
+          "@id": "cred:verifiableCredential",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+    "EcdsaSecp256k1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": {
+          "@id": "sec:expiration",
+          "@type": "xsd:dateTime"
+        },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "EcdsaSecp256r1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": {
+          "@id": "sec:expiration",
+          "@type": "xsd:dateTime"
+        },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "Ed25519Signature2018": {
+      "@id": "https://w3id.org/security#Ed25519Signature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": {
+          "@id": "sec:expiration",
+          "@type": "xsd:dateTime"
+        },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "RsaSignature2018": {
+      "@id": "https://w3id.org/security#RsaSignature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": {
+          "@id": "sec:expiration",
+          "@type": "xsd:dateTime"
+        },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/credentials-v2.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/credentials-v2.jsonld
@@ -1,0 +1,301 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "description": "https://schema.org/description",
+    "digestMultibase": {
+      "@id": "https://w3id.org/security#digestMultibase",
+      "@type": "https://w3id.org/security#multibase"
+    },
+    "digestSRI": {
+      "@id": "https://www.w3.org/2018/credentials#digestSRI",
+      "@type": "https://www.w3.org/2018/credentials#sriString"
+    },
+    "mediaType": {
+      "@id": "https://schema.org/encodingFormat"
+    },
+    "name": "https://schema.org/name",
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "confidenceMethod": {
+          "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
+          "@type": "@id"
+        },
+        "credentialSchema": {
+          "@id": "https://www.w3.org/2018/credentials#credentialSchema",
+          "@type": "@id"
+        },
+        "credentialStatus": {
+          "@id": "https://www.w3.org/2018/credentials#credentialStatus",
+          "@type": "@id"
+        },
+        "credentialSubject": {
+          "@id": "https://www.w3.org/2018/credentials#credentialSubject",
+          "@type": "@id"
+        },
+        "description": "https://schema.org/description",
+        "evidence": {
+          "@id": "https://www.w3.org/2018/credentials#evidence",
+          "@type": "@id"
+        },
+        "issuer": {
+          "@id": "https://www.w3.org/2018/credentials#issuer",
+          "@type": "@id"
+        },
+        "name": "https://schema.org/name",
+        "proof": {
+          "@id": "https://w3id.org/security#proof",
+          "@type": "@id",
+          "@container": "@graph"
+        },
+        "refreshService": {
+          "@id": "https://www.w3.org/2018/credentials#refreshService",
+          "@type": "@id"
+        },
+        "relatedResource": {
+          "@id": "https://www.w3.org/2018/credentials#relatedResource",
+          "@type": "@id"
+        },
+        "renderMethod": {
+          "@id": "https://www.w3.org/2018/credentials#renderMethod",
+          "@type": "@id"
+        },
+        "termsOfUse": {
+          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
+        },
+        "validFrom": {
+          "@id": "https://www.w3.org/2018/credentials#validFrom",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "validUntil": {
+          "@id": "https://www.w3.org/2018/credentials#validUntil",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+    "EnvelopedVerifiableCredential": "https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential",
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "holder": {
+          "@id": "https://www.w3.org/2018/credentials#holder",
+          "@type": "@id"
+        },
+        "proof": {
+          "@id": "https://w3id.org/security#proof",
+          "@type": "@id",
+          "@container": "@graph"
+        },
+        "termsOfUse": {
+          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
+        },
+        "verifiableCredential": {
+          "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
+          "@type": "@id",
+          "@container": "@graph",
+          "@context": null
+        }
+      }
+    },
+    "EnvelopedVerifiablePresentation": "https://www.w3.org/2018/credentials#EnvelopedVerifiablePresentation",
+    "JsonSchemaCredential": "https://www.w3.org/2018/credentials#JsonSchemaCredential",
+    "JsonSchema": {
+      "@id": "https://www.w3.org/2018/credentials#JsonSchema",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "jsonSchema": {
+          "@id": "https://www.w3.org/2018/credentials#jsonSchema",
+          "@type": "@json"
+        }
+      }
+    },
+    "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
+    "BitstringStatusList": {
+      "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "encodedList": {
+          "@id": "https://www.w3.org/ns/credentials/status#encodedList",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "ttl": "https://www.w3.org/ns/credentials/status#ttl"
+      }
+    },
+    "BitstringStatusListEntry": {
+      "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "statusListCredential": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusListCredential",
+          "@type": "@id"
+        },
+        "statusListIndex": "https://www.w3.org/ns/credentials/status#statusListIndex",
+        "statusPurpose": "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "statusMessage": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "message": "https://www.w3.org/ns/credentials/status#message",
+            "status": "https://www.w3.org/ns/credentials/status#status"
+          }
+        },
+        "statusReference": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusReference",
+          "@type": "@id"
+        },
+        "statusSize": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
+          "@type": "https://www.w3.org/2001/XMLSchema#integer"
+        }
+      }
+    },
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "cryptosuite": {
+          "@id": "https://w3id.org/security#cryptosuite",
+          "@type": "https://w3id.org/security#cryptosuiteString"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "previousProof": {
+          "@id": "https://w3id.org/security#previousProof",
+          "@type": "@id"
+        },
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "...": {
+      "@id": "https://www.iana.org/assignments/jwt#..."
+    },
+    "_sd": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd",
+      "@type": "@json"
+    },
+    "_sd_alg": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
+    },
+    "aud": {
+      "@id": "https://www.iana.org/assignments/jwt#aud",
+      "@type": "@id"
+    },
+    "cnf": {
+      "@id": "https://www.iana.org/assignments/jwt#cnf",
+      "@context": {
+        "@protected": true,
+        "kid": {
+          "@id": "https://www.iana.org/assignments/jwt#kid",
+          "@type": "@id"
+        },
+        "jwk": {
+          "@id": "https://www.iana.org/assignments/jwt#jwk",
+          "@type": "@json"
+        }
+      }
+    },
+    "exp": {
+      "@id": "https://www.iana.org/assignments/jwt#exp",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "iat": {
+      "@id": "https://www.iana.org/assignments/jwt#iat",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "iss": {
+      "@id": "https://www.iana.org/assignments/jose#iss",
+      "@type": "@id"
+    },
+    "jku": {
+      "@id": "https://www.iana.org/assignments/jose#jku",
+      "@type": "@id"
+    },
+    "kid": {
+      "@id": "https://www.iana.org/assignments/jose#kid",
+      "@type": "@id"
+    },
+    "nbf": {
+      "@id": "https://www.iana.org/assignments/jwt#nbf",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "sub": {
+      "@id": "https://www.iana.org/assignments/jose#sub",
+      "@type": "@id"
+    },
+    "x5u": {
+      "@id": "https://www.iana.org/assignments/jose#x5u",
+      "@type": "@id"
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/did-v1.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/did-v1.jsonld
@@ -1,0 +1,57 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "alsoKnownAs": {
+      "@id": "https://www.w3.org/ns/activitystreams#alsoKnownAs",
+      "@type": "@id"
+    },
+    "assertionMethod": {
+      "@id": "https://w3id.org/security#assertionMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "authentication": {
+      "@id": "https://w3id.org/security#authenticationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityDelegation": {
+      "@id": "https://w3id.org/security#capabilityDelegationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "capabilityInvocation": {
+      "@id": "https://w3id.org/security#capabilityInvocationMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "controller": {
+      "@id": "https://w3id.org/security#controller",
+      "@type": "@id"
+    },
+    "keyAgreement": {
+      "@id": "https://w3id.org/security#keyAgreementMethod",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "service": {
+      "@id": "https://www.w3.org/ns/did#service",
+      "@type": "@id",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },
+    "verificationMethod": {
+      "@id": "https://w3id.org/security#verificationMethod",
+      "@type": "@id"
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/security-ed25519-2020-v1.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/security-ed25519-2020-v1.jsonld
@@ -1,0 +1,93 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "Ed25519VerificationKey2020": {
+      "@id": "https://w3id.org/security#Ed25519VerificationKey2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "controller": {
+          "@id": "https://w3id.org/security#controller",
+          "@type": "@id"
+        },
+        "revoked": {
+          "@id": "https://w3id.org/security#revoked",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "publicKeyMultibase": {
+          "@id": "https://w3id.org/security#publicKeyMultibase",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+    "Ed25519Signature2020": {
+      "@id": "https://w3id.org/security#Ed25519Signature2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/security-jws-2020-v1.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/security-jws-2020-v1.jsonld
@@ -1,0 +1,78 @@
+{
+  "@context": {
+    "privateKeyJwk": {
+      "@id": "https://w3id.org/security#privateKeyJwk",
+      "@type": "@json"
+    },
+    "JsonWebKey2020": {
+      "@id": "https://w3id.org/security#JsonWebKey2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "publicKeyJwk": {
+          "@id": "https://w3id.org/security#publicKeyJwk",
+          "@type": "@json"
+        }
+      }
+    },
+    "JsonWebSignature2020": {
+      "@id": "https://w3id.org/security#JsonWebSignature2020",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "jws": "https://w3id.org/security#jws",
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/security-v1.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/security-v1.jsonld
@@ -1,0 +1,74 @@
+{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "dc": "http://purl.org/dc/terms/",
+    "sec": "https://w3id.org/security#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "EcdsaKoblitzSignature2016": "sec:EcdsaKoblitzSignature2016",
+    "Ed25519Signature2018": "sec:Ed25519Signature2018",
+    "EncryptedMessage": "sec:EncryptedMessage",
+    "GraphSignature2012": "sec:GraphSignature2012",
+    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "CryptographicKey": "sec:Key",
+    "authenticationTag": "sec:authenticationTag",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
+    "cipherAlgorithm": "sec:cipherAlgorithm",
+    "cipherData": "sec:cipherData",
+    "cipherKey": "sec:cipherKey",
+    "created": {
+      "@id": "dc:created",
+      "@type": "xsd:dateTime"
+    },
+    "creator": {
+      "@id": "dc:creator",
+      "@type": "@id"
+    },
+    "digestAlgorithm": "sec:digestAlgorithm",
+    "digestValue": "sec:digestValue",
+    "domain": "sec:domain",
+    "encryptionKey": "sec:encryptionKey",
+    "expiration": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "expires": {
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
+    },
+    "initializationVector": "sec:initializationVector",
+    "iterationCount": "sec:iterationCount",
+    "nonce": "sec:nonce",
+    "normalizationAlgorithm": "sec:normalizationAlgorithm",
+    "owner": {
+      "@id": "sec:owner",
+      "@type": "@id"
+    },
+    "password": "sec:password",
+    "privateKey": {
+      "@id": "sec:privateKey",
+      "@type": "@id"
+    },
+    "privateKeyPem": "sec:privateKeyPem",
+    "publicKey": {
+      "@id": "sec:publicKey",
+      "@type": "@id"
+    },
+    "publicKeyBase58": "sec:publicKeyBase58",
+    "publicKeyPem": "sec:publicKeyPem",
+    "publicKeyWif": "sec:publicKeyWif",
+    "publicKeyService": {
+      "@id": "sec:publicKeyService",
+      "@type": "@id"
+    },
+    "revoked": {
+      "@id": "sec:revoked",
+      "@type": "xsd:dateTime"
+    },
+    "salt": "sec:salt",
+    "signature": "sec:signature",
+    "signatureAlgorithm": "sec:signingAlgorithm",
+    "signatureValue": "sec:signatureValue"
+  }
+}

--- a/lib/pyld/documentloader/frozen/bundled/security-v2.jsonld
+++ b/lib/pyld/documentloader/frozen/bundled/security-v2.jsonld
@@ -1,0 +1,126 @@
+{
+  "@context": [
+    {
+      "@version": 1.1
+    },
+    "https://w3id.org/security/v1",
+    {
+      "AesKeyWrappingKey2019": "sec:AesKeyWrappingKey2019",
+      "DeleteKeyOperation": "sec:DeleteKeyOperation",
+      "DeriveSecretOperation": "sec:DeriveSecretOperation",
+      "EcdsaSecp256k1Signature2019": "sec:EcdsaSecp256k1Signature2019",
+      "EcdsaSecp256r1Signature2019": "sec:EcdsaSecp256r1Signature2019",
+      "EcdsaSecp256k1VerificationKey2019": "sec:EcdsaSecp256k1VerificationKey2019",
+      "EcdsaSecp256r1VerificationKey2019": "sec:EcdsaSecp256r1VerificationKey2019",
+      "Ed25519Signature2018": "sec:Ed25519Signature2018",
+      "Ed25519VerificationKey2018": "sec:Ed25519VerificationKey2018",
+      "EquihashProof2018": "sec:EquihashProof2018",
+      "ExportKeyOperation": "sec:ExportKeyOperation",
+      "GenerateKeyOperation": "sec:GenerateKeyOperation",
+      "KmsOperation": "sec:KmsOperation",
+      "RevokeKeyOperation": "sec:RevokeKeyOperation",
+      "RsaSignature2018": "sec:RsaSignature2018",
+      "RsaVerificationKey2018": "sec:RsaVerificationKey2018",
+      "Sha256HmacKey2019": "sec:Sha256HmacKey2019",
+      "SignOperation": "sec:SignOperation",
+      "UnwrapKeyOperation": "sec:UnwrapKeyOperation",
+      "VerifyOperation": "sec:VerifyOperation",
+      "WrapKeyOperation": "sec:WrapKeyOperation",
+      "X25519KeyAgreementKey2019": "sec:X25519KeyAgreementKey2019",
+      "allowedAction": "sec:allowedAction",
+      "assertionMethod": {
+        "@id": "sec:assertionMethod",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "authentication": {
+        "@id": "sec:authenticationMethod",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "capability": {
+        "@id": "sec:capability",
+        "@type": "@id"
+      },
+      "capabilityAction": "sec:capabilityAction",
+      "capabilityChain": {
+        "@id": "sec:capabilityChain",
+        "@type": "@id",
+        "@container": "@list"
+      },
+      "capabilityDelegation": {
+        "@id": "sec:capabilityDelegationMethod",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "capabilityInvocation": {
+        "@id": "sec:capabilityInvocationMethod",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "caveat": {
+        "@id": "sec:caveat",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "challenge": "sec:challenge",
+      "ciphertext": "sec:ciphertext",
+      "controller": {
+        "@id": "sec:controller",
+        "@type": "@id"
+      },
+      "delegator": {
+        "@id": "sec:delegator",
+        "@type": "@id"
+      },
+      "equihashParameterK": {
+        "@id": "sec:equihashParameterK",
+        "@type": "xsd:integer"
+      },
+      "equihashParameterN": {
+        "@id": "sec:equihashParameterN",
+        "@type": "xsd:integer"
+      },
+      "invocationTarget": {
+        "@id": "sec:invocationTarget",
+        "@type": "@id"
+      },
+      "invoker": {
+        "@id": "sec:invoker",
+        "@type": "@id"
+      },
+      "jws": "sec:jws",
+      "keyAgreement": {
+        "@id": "sec:keyAgreementMethod",
+        "@type": "@id",
+        "@container": "@set"
+      },
+      "kmsModule": {
+        "@id": "sec:kmsModule"
+      },
+      "parentCapability": {
+        "@id": "sec:parentCapability",
+        "@type": "@id"
+      },
+      "plaintext": "sec:plaintext",
+      "proof": {
+        "@id": "sec:proof",
+        "@type": "@id",
+        "@container": "@graph"
+      },
+      "proofPurpose": {
+        "@id": "sec:proofPurpose",
+        "@type": "@vocab"
+      },
+      "proofValue": "sec:proofValue",
+      "referenceId": "sec:referenceId",
+      "unwrappedKey": "sec:unwrappedKey",
+      "verificationMethod": {
+        "@id": "sec:verificationMethod",
+        "@type": "@id"
+      },
+      "verifyData": "sec:verifyData",
+      "wrappedKey": "sec:wrappedKey"
+    }
+  ]
+}

--- a/scripts/download_contexts.py
+++ b/scripts/download_contexts.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Refresh the JSON-LD contexts bundled with FrozenDocumentLoader.
+
+Fetches each URL in :data:`pyld.documentloader.frozen.BUNDLED_CONTEXTS` over
+HTTPS and writes the response body to the corresponding bundled file path.
+The mapping is the single source of truth — there is no separate manifest
+here.
+
+Run from the repo root::
+
+    python scripts/download_contexts.py
+
+Exits non-zero on any HTTP failure or non-JSON response.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'lib'))
+
+from pyld.documentloader.frozen import BUNDLED_CONTEXTS  # noqa: E402
+
+
+def download() -> int:
+    headers = {'Accept': 'application/ld+json, application/json'}
+    failures: list[str] = []
+    for url, target in BUNDLED_CONTEXTS.items():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            response = requests.get(
+                url, headers=headers, timeout=30, allow_redirects=True
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except Exception as exc:
+            print(f'FAIL {url}: {exc}', file=sys.stderr)
+            failures.append(url)
+            continue
+        target.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False) + '\n',
+            encoding='utf-8',
+        )
+        print(f'OK   {url} -> {target.relative_to(REPO_ROOT)}')
+    if failures:
+        print(
+            f'\n{len(failures)} URL(s) failed; bundle may be incomplete.',
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(download())

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,13 @@ setup(
         'c14n',
         'pyld',
         'pyld.documentloader',
+        'pyld.documentloader.frozen',
     ],
     package_dir={'': 'lib'},
+    package_data={
+        'pyld.documentloader.frozen': ['bundled/*.jsonld'],
+    },
+    include_package_data=True,
     license='BSD 3-Clause license',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/test_frozen_document_loader.py
+++ b/tests/test_frozen_document_loader.py
@@ -1,0 +1,111 @@
+"""Tests for FrozenDocumentLoader and its bundled context set."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pyld import (
+    BUNDLED_CONTEXTS,
+    DocumentLoader,
+    FrozenDocumentLoader,
+    jsonld,
+)
+from pyld.jsonld import JsonLdError
+
+_URL = 'https://example.com/ctx'
+_INLINE_DOC = {'@context': {'name': 'http://schema.org/name'}}
+
+
+def test_loader_returns_remote_document_for_dict_entry():
+    loader = FrozenDocumentLoader(documents={_URL: _INLINE_DOC})
+    result = loader(_URL, {})
+    assert result == {
+        'contentType': 'application/ld+json',
+        'contextUrl': None,
+        'documentUrl': _URL,
+        'document': _INLINE_DOC,
+    }
+
+
+def test_loader_reads_and_parses_path_entry(tmp_path):
+    payload = {'@context': {'foo': 'http://example.com/foo'}}
+    file = tmp_path / 'ctx.jsonld'
+    file.write_text(json.dumps(payload), encoding='utf-8')
+
+    loader = FrozenDocumentLoader(documents={_URL: file})
+    result = loader(_URL, {})
+
+    assert result['document'] == payload
+    assert result['documentUrl'] == _URL
+
+
+def test_path_entries_are_cached_in_place(tmp_path, monkeypatch):
+    payload = {'@context': {'foo': 'http://example.com/foo'}}
+    file = tmp_path / 'ctx.jsonld'
+    file.write_text(json.dumps(payload), encoding='utf-8')
+
+    loader = FrozenDocumentLoader(documents={_URL: file})
+
+    read_calls = 0
+    real_read_text = Path.read_text
+
+    def counting_read_text(self, *args, **kwargs):
+        nonlocal read_calls
+        read_calls += 1
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, 'read_text', counting_read_text)
+
+    loader(_URL, {})
+    loader(_URL, {})
+
+    assert read_calls == 1
+    assert loader.documents[_URL] == payload
+    assert not isinstance(loader.documents[_URL], Path)
+
+
+def test_callers_mapping_is_not_mutated(tmp_path):
+    file = tmp_path / 'ctx.jsonld'
+    file.write_text(json.dumps({'@context': {}}), encoding='utf-8')
+    caller_mapping = {_URL: file}
+
+    loader = FrozenDocumentLoader(documents=caller_mapping)
+    loader(_URL, {})
+
+    assert caller_mapping[_URL] is file
+    assert isinstance(caller_mapping[_URL], Path)
+
+
+def test_unknown_url_raises_load_document_error():
+    loader = FrozenDocumentLoader(documents={})
+    with pytest.raises(JsonLdError) as exc:
+        loader('https://example.com/unknown', {})
+    assert exc.value.code == 'loading document failed'
+    assert exc.value.type == 'jsonld.LoadDocumentError'
+
+
+def test_end_to_end_expand_with_bundled_context():
+    loader = FrozenDocumentLoader()
+    doc = {
+        '@context': 'https://www.w3.org/ns/did/v1',
+        'id': 'did:example:123',
+        'authentication': ['did:example:123#key-1'],
+    }
+    expanded = jsonld.expand(doc, options={'documentLoader': loader})
+    assert expanded[0]['@id'] == 'did:example:123'
+    assert any(k.endswith('authenticationMethod') for k in expanded[0])
+
+
+def test_bundled_contexts_are_valid_jsonld_files():
+    assert len(BUNDLED_CONTEXTS) == 8
+    for url, path in BUNDLED_CONTEXTS.items():
+        assert isinstance(path, Path), url
+        assert path.exists(), f'missing bundled file for {url}: {path}'
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        assert '@context' in payload, f'no @context in bundled file for {url}'
+
+
+def test_document_loader_base_class_is_abstract():
+    with pytest.raises(TypeError):
+        DocumentLoader()

--- a/tests/test_frozen_document_loader.py
+++ b/tests/test_frozen_document_loader.py
@@ -18,6 +18,7 @@ _INLINE_DOC = {'@context': {'name': 'http://schema.org/name'}}
 
 
 def test_loader_returns_remote_document_for_dict_entry():
+    """Inline documents are returned as JSON-LD remote documents."""
     loader = FrozenDocumentLoader(documents={_URL: _INLINE_DOC})
     result = loader(_URL, {})
     assert result == {
@@ -29,6 +30,7 @@ def test_loader_returns_remote_document_for_dict_entry():
 
 
 def test_loader_reads_and_parses_path_entry(tmp_path):
+    """Path entries are read lazily and parsed as JSON when requested."""
     payload = {'@context': {'foo': 'http://example.com/foo'}}
     file = tmp_path / 'ctx.jsonld'
     file.write_text(json.dumps(payload), encoding='utf-8')
@@ -41,6 +43,7 @@ def test_loader_reads_and_parses_path_entry(tmp_path):
 
 
 def test_path_entries_are_cached_in_place(tmp_path, monkeypatch):
+    """Parsed path entries are cached after the first successful load."""
     payload = {'@context': {'foo': 'http://example.com/foo'}}
     file = tmp_path / 'ctx.jsonld'
     file.write_text(json.dumps(payload), encoding='utf-8')
@@ -66,6 +69,7 @@ def test_path_entries_are_cached_in_place(tmp_path, monkeypatch):
 
 
 def test_callers_mapping_is_not_mutated(tmp_path):
+    """Loader-owned caching does not mutate the caller's original mapping."""
     file = tmp_path / 'ctx.jsonld'
     file.write_text(json.dumps({'@context': {}}), encoding='utf-8')
     caller_mapping = {_URL: file}
@@ -78,6 +82,7 @@ def test_callers_mapping_is_not_mutated(tmp_path):
 
 
 def test_unknown_url_raises_load_document_error():
+    """URLs outside the allowlist fail with PyLD's load-document error code."""
     loader = FrozenDocumentLoader(documents={})
     with pytest.raises(JsonLdError) as exc:
         loader('https://example.com/unknown', {})
@@ -86,6 +91,7 @@ def test_unknown_url_raises_load_document_error():
 
 
 def test_end_to_end_expand_with_bundled_context():
+    """Bundled contexts can be used by jsonld.expand without network access."""
     loader = FrozenDocumentLoader()
     doc = {
         '@context': 'https://www.w3.org/ns/did/v1',
@@ -98,6 +104,7 @@ def test_end_to_end_expand_with_bundled_context():
 
 
 def test_bundled_contexts_are_valid_jsonld_files():
+    """Every bundled context entry points to an existing JSON-LD context file."""
     assert len(BUNDLED_CONTEXTS) == 8
     for url, path in BUNDLED_CONTEXTS.items():
         assert isinstance(path, Path), url
@@ -107,5 +114,6 @@ def test_bundled_contexts_are_valid_jsonld_files():
 
 
 def test_document_loader_base_class_is_abstract():
+    """The base class documents the class-loader interface without instantiation."""
     with pytest.raises(TypeError):
         DocumentLoader()


### PR DESCRIPTION
## Why?

For tight security deployments, it might be necessary to:

* Ensure that the system does not require network access and does not download arbitrary data from the Web,
* But still make certain white listed contexts/remote documents available to JSON-LD processing.

## Summary

- Adds `pyld.DocumentLoader` (ABC) + `pyld.RemoteDocument` (`TypedDict`) — the first class-based loader contract in PyLD; existing function-based loaders remain valid.
- Adds `pyld.FrozenDocumentLoader`: a class-based loader that serves only URLs in its `documents` allowlist and refuses everything else with `JsonLdError(code='loading document failed')`. Suitable for air-gapped runs, reproducible builds, and security-hardened deployments. Honors the W3C *JSON-LD Best Practices* recommendation that clients SHOULD attempt to use a locally cached version of contexts ([§ Cache JSON-LD Contexts](https://w3c.github.io/json-ld-bp/#cache-json-ld-contexts)).
- Adds `pyld.BUNDLED_CONTEXTS`: 8 vendored W3C / W3ID JSON-LD contexts (ActivityStreams, DID v1, VC v1/v2, Linked Data Security v1/v2, Ed25519-2020, JWS-2020), refreshable with `make download-bundled-contexts`. With no arguments `FrozenDocumentLoader()` serves these; pass `dict(BUNDLED_CONTEXTS, **extras)` to extend.

### Design notes

- `documents: dict[str, dict | Path]` — `Path` entries are read & parsed lazily on first request and cached in place. `__post_init__` makes a defensive copy so the caller's mapping is never mutated.
- `RemoteDocument` is a real `TypedDict` (previously only a docstring word). Subclasses get a typed `__call__` return.
- Bundled `*.jsonld` files ship via `setup.py`'s `package_data` and `MANIFEST.in`'s `recursive-include`.

## Test plan

- [x] `pytest tests/test_frozen_document_loader.py -v` — 8 new tests, all pass.
- [x] Full non-network suite: `pytest -m "not network"` — 1477 passed, 43 skipped, 14 xfailed.
- [x] `make lint` clean.
- [x] End-to-end smoke: `jsonld.expand(doc_with_did_v1_context, options={'documentLoader': FrozenDocumentLoader()})` resolves with no network.
- [x] Refusal smoke: unknown URL raises `JsonLdError(code='loading document failed', type='jsonld.LoadDocumentError')`.
- [x] Bundle refresh: `make download-bundled-contexts` succeeds and is idempotent.