### PR TITLE
Document compact term selection order change (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 3.0.0 - 2026-04-02
 
 ### Changed
+- **BREAKING**: Compaction term selection now follows the JSON-LD 1.1 spec
+  (Inverse Context Creation, section 4.3 step 3): terms are ordered by
+  shortest first, with lexicographic tiebreak. Previously terms were ordered
+  lexicographically first, then by length. This changes which term is
+  selected when multiple context keys map to the same IRI. See #247.
 - **BREAKING**: Require supported Python version >= 3.10.
 - Update aiohttp document loader to work with Python 3.14.
   - Minimize async related changes to library code in this release.

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -591,6 +591,53 @@ class TestCompact:
         compacted = jsonld.compact(input, context)
         assert compacted == expected
 
+    # Issue 247 - term selection order during compaction
+    def test_compact_prefers_shortest_term(self):
+        """
+        When two terms map to the same IRI, compaction should prefer the
+        shorter term, per the Inverse Context Creation algorithm (spec
+        section 4.3 step 3: "ordered by shortest term first").
+        """
+        context = {
+            "schema": "https://schema.org/",
+            "name": "schema:name",
+            "full_name": "schema:name",
+        }
+        doc = {"https://schema.org/name": [{"@value": "Alice"}]}
+        result = jsonld.compact(doc, context)
+        assert "name" in result
+        assert "full_name" not in result
+
+    def test_compact_shortest_wins_over_underscore_prefix(self):
+        """
+        A shorter term should be preferred even when a longer
+        underscore-prefixed term sorts lexicographically first.
+        """
+        context = {
+            "schema": "https://schema.org/",
+            "name": "schema:name",
+            "_internal_name": {"@id": "schema:name"},
+        }
+        doc = {"https://schema.org/name": [{"@value": "Alice"}]}
+        result = jsonld.compact(doc, context)
+        assert "name" in result
+        assert "_internal_name" not in result
+
+    def test_compact_same_length_uses_lexicographic_tiebreak(self):
+        """
+        When two terms of the same length map to the same IRI, the
+        lexicographically least term (by code point order) should win.
+        """
+        context = {
+            "schema": "https://schema.org/",
+            "name": "schema:name",
+            "nick": "schema:name",
+        }
+        doc = {"https://schema.org/name": [{"@value": "Alice"}]}
+        result = jsonld.compact(doc, context)
+        assert "name" in result
+        assert "nick" not in result
+
     # Issue 91
     def test_empty_context(self):
         """


### PR DESCRIPTION
## Summary
- Add changelog entry documenting the compaction term selection order change as a **BREAKING** change in 3.0.0
- Add three unit tests to `TestCompact` verifying the spec-compliant behavior:
  - Shorter term is preferred over lexicographically-first longer term
  - Underscore-prefixed longer terms do not beat shorter terms
  - Same-length terms use lexicographic tiebreak

Addresses #247. The term ordering now matches the [W3C JSON-LD 1.1 API spec, section 4.3 step 3](https://w3c.github.io/json-ld-api/#inverse-context-creation): *"ordered by shortest term first (breaking ties by choosing the lexicographically least term)"*.

## Test plan
- [x] `pytest tests/test_jsonld.py::TestCompact` passes (5/5)