### PR TITLE
Fix compaction test t0112 and t0113

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1893,10 +1893,10 @@ class JsonLdProcessor:
                             )
                             if not index_key:
                                 index_key = '@index'
-                            container_key = self._compact_iri(
-                                active_ctx, index_key, vocab=True
-                            )
                             if index_key == '@index':
+                                container_key = self._compact_iri(
+                                    active_ctx, index_key, vocab=True
+                                )
                                 key = expanded_item.get('@index')
                                 if (
                                     _is_object(compacted_item)
@@ -1904,10 +1904,27 @@ class JsonLdProcessor:
                                 ):
                                     del compacted_item[container_key]
                             else:
+                                # Expand a term or compact IRI index mapping before re-compacting it.
+                                expanded_index_key = self._expand_iri(
+                                    active_ctx, index_key, vocab=True
+                                )
+                                # Term selection for the index property can depend on its value.
+                                index_value = JsonLdProcessor.arrayify(
+                                    expanded_item.get(expanded_index_key, [])
+                                )
+                                # Index maps use the first value as the map key.
+                                index_value = index_value[0] if index_value else None
+                                # Re-compact with the value so terms like predicate beat rdf:predicate.
+                                container_key = self._compact_iri(
+                                    active_ctx,
+                                    expanded_index_key,
+                                    index_value,
+                                    vocab=True,
+                                )
                                 indexes = []
                                 if _is_object(compacted_item):
                                     indexes = JsonLdProcessor.arrayify(
-                                        compacted_item.get(index_key, [])
+                                        compacted_item.get(container_key, [])
                                     )
                                 if not indexes or not _is_string(indexes[0]):
                                     key = None
@@ -1919,11 +1936,11 @@ class JsonLdProcessor:
                                         and len(indexes) == 0
                                         and _is_object(compacted_item)
                                     ):
-                                        del compacted_item[index_key]
+                                        del compacted_item[container_key]
                                     elif len(indexes) == 1:
-                                        compacted_item[index_key] = indexes[0]
+                                        compacted_item[container_key] = indexes[0]
                                     else:
-                                        compacted_item[index_key] = indexes
+                                        compacted_item[container_key] = indexes
                         elif '@id' in container:
                             id_key = self._compact_iri(
                                 active_ctx, '@id', base=options.get('base', '')

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -906,7 +906,6 @@ TEST_TYPES = {
             'specVersion': ['json-ld-1.0'],
             'idRegex': [
                 # uncategorized
-                '.*compact-manifest#t0112$',
                 '.*compact-manifest#tm023$',
                 '.*compact-manifest#t0113$',
                 '.*compact-manifest#tc028$',

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -907,7 +907,6 @@ TEST_TYPES = {
             'idRegex': [
                 # uncategorized
                 '.*compact-manifest#tm023$',
-                '.*compact-manifest#t0113$',
                 '.*compact-manifest#tc028$',
             ],
         },

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -777,6 +777,96 @@ class TestCompact:
         assert "name" in result
         assert "nick" not in result
 
+    def test_index_map_with_compact_iri_index_round_trips(self):
+        """
+        When an @index container uses a compact IRI as its @index mapping,
+        compaction should use the indexed property value as the map key and
+        preserve the expanded representation on round-trip.
+        """
+        context = {
+            "@context": {
+                "ex": "http://example.com/",
+                "items": {
+                    "@id": "ex:items",
+                    "@container": "@index",
+                    "@index": "ex:rank",
+                },
+            }
+        }
+        expanded = [
+            {
+                "http://example.com/items": [
+                    {
+                        "http://example.com/rank": [{"@value": "first"}],
+                        "http://example.com/name": [{"@value": "Alice"}],
+                    }
+                ]
+            }
+        ]
+
+        compacted = jsonld.compact(expanded, context, {"skipExpansion": True})
+
+        assert compacted == {
+            "@context": context["@context"],
+            "items": {"first": {"ex:name": "Alice"}},
+        }
+        assert jsonld.expand(compacted) == expanded
+
+    def test_reverse_index_map_with_term_index_uses_property_value_as_key(self):
+        """
+        When an @index container uses a term as its @index mapping, compaction
+        should still find the property key selected using the indexed value.
+        """
+        context = {
+            "@context": {
+                "@version": 1.1,
+                "@base": "https://example.org/",
+                "@vocab": "https://example.net/ns#",
+                "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                "statement": {
+                    "@reverse": "rdf:subject",
+                    "@container": "@index",
+                    "@index": "predicate",
+                },
+                "predicate": {"@id": "rdf:predicate", "@type": "@vocab"},
+                "term": {"@id": "rdf:object", "@type": "@vocab"},
+                "addedIn": {"@type": "@id"},
+            }
+        }
+        expanded = [
+            {
+                "@id": "https://example.org/item/1",
+                "@reverse": {
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#subject": [
+                        {
+                            "https://example.net/ns#addedIn": [
+                                {"@id": "https://example.org/v1"}
+                            ],
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#object": [
+                                {"@id": "https://example.net/ns#A"}
+                            ],
+                            "http://www.w3.org/1999/02/22-rdf-syntax-ns#predicate": [
+                                {
+                                    "@id": (
+                                        "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                                        "type"
+                                    )
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ]
+
+        compacted = jsonld.compact(expanded, context, {"skipExpansion": True})
+
+        assert compacted == {
+            "@context": context["@context"],
+            "@id": "item/1",
+            "statement": {"rdf:type": {"term": "A", "addedIn": "v1"}},
+        }
+
     # Issue 91
     def test_empty_context(self):
         """


### PR DESCRIPTION
Fixes tests 

- https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0112:

> With @container: @index and @index a compact IRI, ensure round-tripping of compacted representation

- https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0113

> With @container: @index and @index an absolute IRI, ensure round-tripping of compacted representation

`_compact()` immediately compacted the term or compact IRI index mapping, also when the index key was not `@index`.  Therefore, it would sometimes pick the wrong term to compact and use as container key.

The fix expands the index mapping first, then compacts that expanded IRI, matching the JSON-LD API compaction correction for compact-IRI index mappings: https://www.w3.org/TR/json-ld11-api/#compaction-algorithm.  After expanding the custom @index mapping, it compacts it with the first indexed value when available. That keeps ex:rank from tripping the prefix-confusion guard, while still selecting predicate instead of rdf:predicate for the reverse-term case.