### PR TITLE
Ensure .pop() and key inspection only occur for objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.1.0 - unreleased
 
+### Fixed
+- When compacting, expands the index mapping first, then compacts that expanded IRI, matching the JSON-LD API compaction correction for compact-IRI index mappings. Fixes testcases [compact#t0112](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0112) and [compact#t0113](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0113).
+- Fixes `AttributeError` when compacting with `@none`: the `@type` map compaction path now only calls `.pop()` and inspects keys when `compacted_item` is actually an object. Fixes [compact#tm023](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tm023)
+
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,
   with a `RemoteDocument` `TypedDict` describing the expected return shape.

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1947,10 +1947,14 @@ class JsonLdProcessor:
                             )
                             key = compacted_item.pop(id_key, None)
                         elif '@type' in container:
+                            # Compact a type-map item an object or scalar (for
+                            # example when a node reference is coerced to @id.
                             type_key = self._compact_iri(active_ctx, '@type')
+                            # Only object items can carry an embedded @type,
+                            # so only call .pop() on object to avoid AttributeError.
                             types = JsonLdProcessor.arrayify(
                                 compacted_item.pop(type_key, [])
-                            )
+                            ) if _is_object(compacted_item) else []
                             key = types.pop(0) if types else None
                             if types:
                                 JsonLdProcessor.add_value(
@@ -1960,7 +1964,8 @@ class JsonLdProcessor:
                             # if compactedItem contains a single entry
                             # whose key maps to @id, recompact without @type
                             if (
-                                len(compacted_item.keys()) == 1
+                                _is_object(compacted_item)
+                                and len(compacted_item.keys()) == 1
                                 and '@id' in expanded_item
                             ):
                                 compacted_item = self._compact(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -906,7 +906,6 @@ TEST_TYPES = {
             'specVersion': ['json-ld-1.0'],
             'idRegex': [
                 # uncategorized
-                '.*compact-manifest#tm023$',
                 '.*compact-manifest#tc028$',
             ],
         },

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -867,6 +867,31 @@ class TestCompact:
             "statement": {"rdf:type": {"term": "A", "addedIn": "v1"}},
         }
 
+    def test_node_reference_compacts_to_string_value_of_type_map(self):
+        """
+        A node reference in a type map can compact to a string when the term
+        is type-coerced to @id. In that case the type map should use @none.
+        """
+        input = {
+            "@context": {"@vocab": "http://schema.org/"},
+            "@type": "Event",
+            "location": {"@id": "http://kg.artsdata.ca/resource/K11-200"},
+        }
+        context = {
+            "@context": {
+                "@vocab": "http://schema.org/",
+                "location": {"@type": "@id", "@container": "@type"},
+            }
+        }
+
+        compacted = jsonld.compact(input, context)
+
+        assert compacted == {
+            "@context": context["@context"],
+            "@type": "Event",
+            "location": {"@none": "http://kg.artsdata.ca/resource/K11-200"},
+        }
+
     # Issue 91
     def test_empty_context(self):
         """


### PR DESCRIPTION
This PR fixes https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tm023

> Uses @none when compacted item is an IRI string

which would raise a `AttributeError: 'str' object has no attribute 'pop'`

The @type map compaction path now only calls .pop() and inspects keys when compacted_item is actually an object, so scalar compacted values like the location string fall through to @none. This prevents the `AttributeError`.