### PR TITLE
Fix compact tc028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - When compacting, expands the index mapping first, then compacts that expanded IRI, matching the JSON-LD API compaction correction for compact-IRI index mappings. Fixes testcases [compact#t0112](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0112) and [compact#t0113](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0113).
 - Fixes `AttributeError` when compacting with `@none`: the `@type` map compaction path now only calls `.pop()` and inspects keys when `compacted_item` is actually an object. Fixes [compact#tm023](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tm023)
+- An empty property-scoped context no longer resets the active context in `_create_term_definition`. Now only explicit null becomes False; empty contexts are preserved. Fixes [compact#tc028](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tc028) and [toRdf#tc036](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tc036).
 
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -5709,8 +5709,10 @@ class JsonLdProcessor:
 
         # scoped contexts
         if '@context' in value:
-            # record as falss, if None
-            mapping['@context'] = value['@context'] if value['@context'] else False
+            # record as false, if None
+            mapping['@context'] = (
+                False if value['@context'] is None else value['@context']
+            )
 
         if '@language' in value and '@type' not in value:
             language = value['@language']

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1030,7 +1030,6 @@ TEST_TYPES = {
                 '.*toRdf-manifest#ter56$',
                 '.*toRdf-manifest#tli12$',
                 '.*toRdf-manifest#tli14$',
-                '.*toRdf-manifest#tc036$',
                 '.*toRdf-manifest#tc037$',
             ]
         },

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -904,10 +904,7 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # uncategorized
-                '.*compact-manifest#tc028$',
-            ],
+            'idRegex': [],
         },
         'fn': 'compact',
         'params': [

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -892,6 +892,37 @@ class TestCompact:
             "location": {"@none": "http://kg.artsdata.ca/resource/K11-200"},
         }
 
+    def test_empty_property_scoped_context_preserves_outer_terms(self):
+        """
+        An empty property-scoped context should not reset the active context
+        during compaction.
+        """
+        expanded = [
+            {
+                "http://example.com/title": [{"@value": "top"}],
+                "http://example.com/thing": [
+                    {
+                        "http://example.com/title": [{"@value": "sub"}],
+                    }
+                ],
+            }
+        ]
+        context = {
+            "@context": {
+                "ex": "http://example.com/",
+                "thing": {"@id": "ex:thing", "@context": {}},
+                "title": "ex:title",
+            }
+        }
+
+        compacted = jsonld.compact(expanded, context, {"skipExpansion": True})
+
+        assert compacted == {
+            "@context": context["@context"],
+            "title": "top",
+            "thing": {"title": "sub"},
+        }
+
     # Issue 91
     def test_empty_context(self):
         """


### PR DESCRIPTION
This PR fixes two related tests in the test-suite:

https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tc028 (this also means 100% spec compliance on compaction)

> Adding a minimal/empty property-scoped context should not affect the using terms defined in outer context.

https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tc036

> Adding a minimal/empty property-scoped context should not affect expansion of terms defined in the outer scope.

The issue probably originated from the Javascript port, where empty objects are truthy. Python treats an empty {} as falsey, so @context: {} was stored as False, which later means "reset/nullify the context." Now only explicit null becomes False; empty contexts are preserved.