### PR TITLE
Fix test manifest options and handle @json type gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - When compacting, expands the index mapping first, then compacts that expanded IRI, matching the JSON-LD API compaction correction for compact-IRI index mappings. Fixes testcases [compact#t0112](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0112) and [compact#t0113](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#t0113).
 - Fixes `AttributeError` when compacting with `@none`: the `@type` map compaction path now only calls `.pop()` and inspects keys when `compacted_item` is actually an object. Fixes [compact#tm023](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tm023)
 - An empty property-scoped context no longer resets the active context in `_create_term_definition`. Now only explicit null becomes False; empty contexts are preserved. Fixes [compact#tc028](https://w3c.github.io/json-ld-api/tests/compact-manifest.html#tc028) and [toRdf#tc036](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tc036).
+- Options from the test manifest now override the options configured in `create_test_options()`, instead of the other way around. This fixes tests not able to override default options in the test-setup such as `extractAllScripts`. Fixes [html#tf004](https://w3c.github.io/json-ld-api/tests/html-manifest#tf004).
+- When `@type` is `@json` in a frame, it no longer raises an "Invalid JSON-LD syntax" error. Fixes [frame#t0069](https://w3c.github.io/json-ld-framing/tests/frame-manifest.html#t0069).
 
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1277,7 +1277,7 @@ class JsonLdProcessor:
 
         :return: all of the values for a subject's property as an array.
         """
-        return JsonLdProcessor.arrayify(subject.get(property) or [])
+        return JsonLdProcessor.arrayify(subject.get(property)) if property in subject else []
 
     @staticmethod
     def remove_property(subject, property):
@@ -4487,8 +4487,10 @@ class JsonLdProcessor:
                     )
         if '@type' in frame[0]:
             for type_ in JsonLdProcessor.arrayify(frame[0]['@type']):
-                # @id must be wildcard or IRI
-                if not (_is_object(type_) or _is_absolute_iri(type_)) or (
+                # @type must be wildcard, @json, or IRI
+                if not (
+                    _is_object(type_) or type_ == '@json' or _is_absolute_iri(type_)
+                ) or (
                     _is_string(type_) and type_.startswith('_:')
                 ):
                     raise JsonLdError(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -970,10 +970,7 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # uncategorized
-                '.*frame-manifest#t0069$',
-            ],
+            'idRegex': [],
         },
         'fn': 'frame',
         'params': [

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -658,11 +658,12 @@ def create_test_options(opts=None):
         http_options = ['contentType', 'httpLink', 'httpStatus', 'redirectTo']
         test_options = test.data.get('option', {})
         options = {}
+        options.update(opts or {})
+        # Non-http options from manifest get priority over configured options
         for k, v in test_options.items():
             if k not in http_options:
                 options[k] = v
         options['documentLoader'] = create_document_loader(test)
-        options.update(opts or {})
         if 'expandContext' in options:
             filename = os.path.join(test.dirname, options['expandContext'])
             options['expandContext'] = read_json(filename)
@@ -954,16 +955,13 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # uncategorized html
-                '.*html-manifest#tf004$',
-            ],
+            'idRegex': [],
         },
         'fn': 'flatten',
         'params': [
             read_test_url('input'),
             read_test_property('context'),
-            create_test_options(),
+            create_test_options({"extractAllScripts": False}),
         ],
     },
     'jld:FrameTest': {


### PR DESCRIPTION
This PR fixes the last outstanding tests for `flatten()` and `frame()`.
In includes two fixes:
- Options from the test manifest now override the options configured in `create_test_options()`, instead of the other way around. In case of `extractAllScripts`, the default is `True`, while most tests except one expect `False`. However, in the test manifest `False` is the default and therefore not explicitly provided. Hence,  there was no way to provide this value through the test setup.
- When `@type` is `@json` in a frame, it no longer raises an "Invalid JSON-LD syntax" error. 