### PR TITLE
Add test case for compaction with @vocab

### DIFF
--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1,3 +1,6 @@
+import json
+
+import pyld
 import pytest
 
 import pyld.jsonld as jsonld
@@ -968,4 +971,26 @@ class TestCompact:
 
         compacted = jsonld.compact(input, {"@vocab": "http://example.org#"}, {"skipExpansion": True})
         expected = {"@context": {"@vocab": "http://example.org#"}, "name": "Bob"}
+        assert compacted == expected
+
+    # Issue 83
+    def test_with_vocab(self):
+        ctx = {'@vocab': 'http://ex.org/#', 'path': {'@type': '@id'}}
+        input = {
+            'http://ex.org/#maxCount': 1,
+            'http://ex.org/#path': 'http://ex.org/#shortname'
+        }
+        expected = {
+            "@context": {
+                "@vocab": "http://ex.org/#",
+                "path": {
+                "@type": "@id"
+                }
+            },
+            "maxCount": 1,
+            "path": "http://ex.org/#shortname"
+        }
+
+        compacted = jsonld.compact(input, ctx)
+
         assert compacted == expected

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -974,21 +974,34 @@ class TestCompact:
         assert compacted == expected
 
     # Issue 83
-    def test_with_vocab(self):
+    def test_with_vocab_no_id(self):
+        """
+        Compacting with @vocab should not compact a plain string value
+        """
         ctx = {'@vocab': 'http://ex.org/#', 'path': {'@type': '@id'}}
         input = {
-            'http://ex.org/#maxCount': 1,
-            'http://ex.org/#path': 'http://ex.org/#shortname'
+            'http://ex.org/#path': 'http://ex.org/#shortname',
         }
         expected = {
-            "@context": {
-                "@vocab": "http://ex.org/#",
-                "path": {
-                "@type": "@id"
-                }
-            },
-            "maxCount": 1,
-            "path": "http://ex.org/#shortname"
+            "@context": {"@vocab": "http://ex.org/#", "path": {"@type": "@id"}},
+            "http://ex.org/#path": "http://ex.org/#shortname",
+        }
+
+        compacted = jsonld.compact(input, ctx)
+
+        assert compacted == expected
+
+    def test_with_vocab_with_id(self):
+        """
+        Compacting with @vocab should compact an @id value
+        """
+        ctx = {'@vocab': 'http://ex.org/#', 'path': {'@type': '@id'}}
+        input = {
+            'http://ex.org/#path': {'@id': 'http://ex.org/#shortname'},
+        }
+        expected = {
+            "@context": {"@vocab": "http://ex.org/#", "path": {"@type": "@id"}},
+            "path": "http://ex.org/#shortname",
         }
 
         compacted = jsonld.compact(input, ctx)

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1,6 +1,3 @@
-import json
-
-import pyld
 import pytest
 
 import pyld.jsonld as jsonld


### PR DESCRIPTION
Fixes #83 (or rather verifies the expected behaviour): Compacting with @vocab should not compact a plain string value, but should compact an `@id` value.