### PR TITLE
[#261]: Refactor document loaders to subclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sw[op]
 *~
 .coverage
+.venv/
 .project
 .pydevproject
 .settings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ Read [CONTRIBUTING.rst](CONTRIBUTING.rst) for code style, linting (e.g. `make li
 - For brand-new test files, prefer function-based pytest tests (module-level `def test_...`) over class-based tests.
 - Use descriptive test names that reflect behavior (e.g. `test_remote_context_via_link_alternate`).
 
+## Documentation
+
+- When adding or promoting public top-level API exports, reflect them in the project documentation, especially the Sphinx API reference under `docs/`.
+
 ## Committing
 
 - Prefer one file per commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 - Options from the test manifest now override the options configured in `create_test_options()`, instead of the other way around. This fixes tests not able to override default options in the test-setup such as `extractAllScripts`. Fixes [html#tf004](https://w3c.github.io/json-ld-api/tests/html-manifest#tf004).
 - When `@type` is `@json` in a frame, it no longer raises an "Invalid JSON-LD syntax" error. Fixes [frame#t0069](https://w3c.github.io/json-ld-framing/tests/frame-manifest.html#t0069).
 
+### Changed
+- `requests_document_loader()` and `aiohttp_document_loader()` now return
+  class-based `DocumentLoader` instances while preserving the existing
+  callable factory API.
+
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,
   with a `RemoteDocument` `TypedDict` describing the expected return shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 ### Changed
 - `requests_document_loader()` and `aiohttp_document_loader()` now return
   class-based `DocumentLoader` instances while preserving the existing
-  callable factory API.
+  callable factory API. The concrete `RequestsDocumentLoader` and
+  `AioHttpDocumentLoader` classes are also importable from `pyld`.
 
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,15 @@ disable verification, or set other Requests_ parameters.
 
     jsonld.set_document_loader(jsonld.requests_document_loader(timeout=...))
 
+The factory remains the compatibility API, and the concrete class is also
+available when class-based construction is preferred:
+
+.. code-block:: Python
+
+    from pyld import RequestsDocumentLoader
+
+    jsonld.set_document_loader(RequestsDocumentLoader(timeout=...))
+
 An asynchronous document loader using aiohttp_ is also available. Please note
 that this document loader limits asynchronicity to fetching documents only.
 The processing loops remain synchronous.
@@ -164,6 +173,14 @@ The processing loops remain synchronous.
 .. code-block:: Python
 
     jsonld.set_document_loader(jsonld.aiohttp_document_loader(timeout=...))
+
+The concrete aiohttp loader class is available from ``pyld`` as well:
+
+.. code-block:: Python
+
+    from pyld import AioHttpDocumentLoader
+
+    jsonld.set_document_loader(AioHttpDocumentLoader(timeout=...))
 
 When no document loader is specified, the default loader is set to Requests_.
 If Requests_ is not available, the loader is set to aiohttp_. The fallback

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,10 @@ API Reference
 .. module:: pyld
 .. autoclass:: DocumentLoader
    :members:
+.. autoclass:: RequestsDocumentLoader
+   :members:
+.. autoclass:: AioHttpDocumentLoader
+   :members:
 .. autoclass:: FrozenDocumentLoader
    :members:
 .. autodata:: BUNDLED_CONTEXTS

--- a/lib/pyld/__init__.py
+++ b/lib/pyld/__init__.py
@@ -2,14 +2,18 @@
 
 from . import jsonld
 from .context_resolver import ContextResolver
+from .documentloader.aiohttp import AioHttpDocumentLoader
 from .documentloader.base import DocumentLoader, RemoteDocument
 from .documentloader.frozen import BUNDLED_CONTEXTS, FrozenDocumentLoader
+from .documentloader.requests import RequestsDocumentLoader
 
 __all__ = [
+    'AioHttpDocumentLoader',
     'BUNDLED_CONTEXTS',
     'ContextResolver',
     'DocumentLoader',
     'FrozenDocumentLoader',
+    'RequestsDocumentLoader',
     'RemoteDocument',
     'jsonld',
 ]

--- a/lib/pyld/documentloader/aiohttp.py
+++ b/lib/pyld/documentloader/aiohttp.py
@@ -14,6 +14,7 @@ import threading
 import urllib.parse as urllib_parse
 
 from pyld import iri_resolver
+from pyld.documentloader.base import DocumentLoader, RemoteDocument
 from pyld.jsonld import (JsonLdError, parse_link_header, LINK_HEADER_REL)
 
 
@@ -38,19 +39,18 @@ def _ensure_background_loop():
     return _background_loop
 
 
-def aiohttp_document_loader(loop=None, secure=False, **kwargs):
-    """
-    Create an Asynchronous document loader using aiohttp.
+class AioHttpDocumentLoader(DocumentLoader):
+    """Remote document loader using aiohttp."""
 
-    :param loop: deprecated / ignored (kept for backward compatibility).
-    :param secure: require all requests to use HTTPS (default: False).
-    :param **kwargs: extra keyword args for the aiohttp request get() call.
+    def __init__(self, loop=None, secure=False, **kwargs):
+        import aiohttp
 
-    :return: the RemoteDocument loader function.
-    """
-    import aiohttp
+        self.aiohttp = aiohttp
+        self.loop = loop
+        self.secure = secure
+        self.kwargs = kwargs
 
-    async def async_loader(url, headers):
+    async def async_loader(self, url, headers) -> RemoteDocument:
         """
         Retrieves JSON-LD at the given URL asynchronously.
 
@@ -71,17 +71,17 @@ def aiohttp_document_loader(loop=None, secure=False, **kwargs):
                     'only "http" and "https" URLs are supported.',
                     'jsonld.InvalidUrl', {'url': url},
                     code='loading document failed')
-            if secure and pieces.scheme != 'https':
+            if self.secure and pieces.scheme != 'https':
                 raise JsonLdError(
                     'URL could not be dereferenced; '
                     'secure mode enabled and '
                     'the URL\'s scheme is not "https".',
                     'jsonld.InvalidUrl', {'url': url},
                     code='loading document failed')
-            async with aiohttp.ClientSession() as session:
+            async with self.aiohttp.ClientSession() as session:
                 async with session.get(url,
                                        headers=headers,
-                                       **kwargs) as response:
+                                       **self.kwargs) as response:
                     content_type = response.headers.get('content-type')
                     if not content_type:
                         content_type = 'application/octet-stream'
@@ -111,8 +111,9 @@ def aiohttp_document_loader(loop=None, secure=False, **kwargs):
                                 linked_alternate.get('type') == 'application/ld+json' and
                                 not re.match(r'^application\/(\w*\+)?json$', content_type)):
                             doc['contentType'] = 'application/ld+json'
-                            doc['documentUrl'] = iri_resolver.resolve(linked_alternate['target'], url)
-                            return await async_loader(doc['documentUrl'], headers)
+                            doc['documentUrl'] = iri_resolver.resolve(
+                                linked_alternate['target'], url)
+                            return await self.async_loader(doc['documentUrl'], headers)
                     doc['document'] = await response.json(content_type=None)
                     return doc
         except JsonLdError as e:
@@ -120,10 +121,10 @@ def aiohttp_document_loader(loop=None, secure=False, **kwargs):
         except Exception as cause:
             raise JsonLdError(
                 'Could not retrieve a JSON-LD document from the URL.',
-                'jsonld.LoadDocumentError', 
+                'jsonld.LoadDocumentError',
                 code='loading document failed') from cause
 
-    def loader(url, options=None):
+    def __call__(self, url, options=None) -> RemoteDocument:
         """
         Retrieves JSON-LD at the given URL synchronously.
 
@@ -147,11 +148,23 @@ def aiohttp_document_loader(loop=None, secure=False, **kwargs):
 
         # Sync environment
         if not running_loop or not running_loop.is_running():
-            return asyncio.run(async_loader(url, headers))
+            return asyncio.run(self.async_loader(url, headers))
 
         # Inside async environment: use background event loop
         loop = _ensure_background_loop()
-        future = asyncio.run_coroutine_threadsafe(async_loader(url, headers), loop)
+        future = asyncio.run_coroutine_threadsafe(
+            self.async_loader(url, headers), loop)
         return future.result()
 
-    return loader
+
+def aiohttp_document_loader(loop=None, secure=False, **kwargs):
+    """
+    Create an Asynchronous document loader using aiohttp.
+
+    :param loop: deprecated / ignored (kept for backward compatibility).
+    :param secure: require all requests to use HTTPS (default: False).
+    :param **kwargs: extra keyword args for the aiohttp request get() call.
+
+    :return: the RemoteDocument loader function.
+    """
+    return AioHttpDocumentLoader(loop=loop, secure=secure, **kwargs)

--- a/lib/pyld/documentloader/aiohttp.py
+++ b/lib/pyld/documentloader/aiohttp.py
@@ -42,11 +42,10 @@ def _ensure_background_loop():
 class AioHttpDocumentLoader(DocumentLoader):
     """Remote document loader using aiohttp."""
 
-    def __init__(self, loop=None, secure=False, **kwargs):
+    def __init__(self, secure=False, **kwargs):
         import aiohttp
 
         self.aiohttp = aiohttp
-        self.loop = loop
         self.secure = secure
         self.kwargs = kwargs
 
@@ -167,4 +166,4 @@ def aiohttp_document_loader(loop=None, secure=False, **kwargs):
 
     :return: the RemoteDocument loader function.
     """
-    return AioHttpDocumentLoader(loop=loop, secure=secure, **kwargs)
+    return AioHttpDocumentLoader(secure=secure, **kwargs)

--- a/lib/pyld/documentloader/base.py
+++ b/lib/pyld/documentloader/base.py
@@ -28,10 +28,8 @@ class DocumentLoader(ABC):
     Concrete subclasses implement :meth:`__call__` to fetch a document for a
     given URL and return a :class:`RemoteDocument`.
 
-    Existing function-based loaders (:func:`pyld.jsonld.requests_document_loader`,
-    :func:`pyld.jsonld.aiohttp_document_loader`) remain valid: pyld's loader
-    contract is "any callable with the right signature". This ABC is for new
-    class-based loaders only.
+    PyLD's loader contract remains "any callable with the right signature".
+    This ABC documents the interface used by built-in class-based loaders.
     """
 
     @abstractmethod

--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -14,24 +14,21 @@ import string
 import urllib.parse as urllib_parse
 
 from pyld import iri_resolver
+from pyld.documentloader.base import DocumentLoader, RemoteDocument
 from pyld.jsonld import JsonLdError, parse_link_header, LINK_HEADER_REL
 
 
-def requests_document_loader(secure=False, **kwargs):
-    """
-    Create a Requests document loader.
+class RequestsDocumentLoader(DocumentLoader):
+    """Remote document loader using Requests."""
 
-    Can be used to setup extra Requests args such as verify, cert, timeout,
-    or others.
+    def __init__(self, secure=False, **kwargs):
+        import requests
 
-    :param secure: require all requests to use HTTPS (default: False).
-    :param **kwargs: extra keyword args for Requests get() call.
+        self.requests = requests
+        self.secure = secure
+        self.kwargs = kwargs
 
-    :return: the RemoteDocument loader function.
-    """
-    import requests
-
-    def loader(url, options={}):
+    def __call__(self, url, options=None) -> RemoteDocument:
         """
         Retrieves JSON-LD at the given URL.
 
@@ -39,6 +36,8 @@ def requests_document_loader(secure=False, **kwargs):
 
         :return: the RemoteDocument.
         """
+        if options is None:
+            options = {}
         try:
             # validate URL
             pieces = urllib_parse.urlparse(url)
@@ -51,7 +50,7 @@ def requests_document_loader(secure=False, **kwargs):
                     'URLs are supported.',
                     'jsonld.InvalidUrl', {'url': url},
                     code='loading document failed')
-            if secure and pieces.scheme != 'https':
+            if self.secure and pieces.scheme != 'https':
                 raise JsonLdError(
                     'URL could not be dereferenced; secure mode enabled and '
                     'the URL\'s scheme is not "https".',
@@ -62,7 +61,7 @@ def requests_document_loader(secure=False, **kwargs):
                 headers = {
                     'Accept': 'application/ld+json, application/json'
                 }
-            response = requests.get(url, headers=headers, **kwargs)
+            response = self.requests.get(url, headers=headers, **self.kwargs)
 
             content_type = response.headers.get('content-type')
             if not content_type:
@@ -93,8 +92,9 @@ def requests_document_loader(secure=False, **kwargs):
                         linked_alternate.get('type') == 'application/ld+json' and
                         not re.match(r'^application\/(\w*\+)?json$', content_type)):
                     doc['contentType'] = 'application/ld+json'
-                    doc['documentUrl'] = iri_resolver.resolve(linked_alternate['target'], url)
-                    return loader(doc['documentUrl'], options=options)
+                    doc['documentUrl'] = iri_resolver.resolve(
+                        linked_alternate['target'], url)
+                    return self(doc['documentUrl'], options=options)
             doc['document'] = response.json()
             return doc
         except JsonLdError as e:
@@ -105,4 +105,17 @@ def requests_document_loader(secure=False, **kwargs):
                 'jsonld.LoadDocumentError',
                 code='loading document failed') from cause
 
-    return loader
+
+def requests_document_loader(secure=False, **kwargs):
+    """
+    Create a Requests document loader.
+
+    Can be used to setup extra Requests args such as verify, cert, timeout,
+    or others.
+
+    :param secure: require all requests to use HTTPS (default: False).
+    :param **kwargs: extra keyword args for Requests get() call.
+
+    :return: the RemoteDocument loader function.
+    """
+    return RequestsDocumentLoader(secure=secure, **kwargs)

--- a/tests/test_document_loader.py
+++ b/tests/test_document_loader.py
@@ -10,9 +10,12 @@ Tests for document loaders: Accept header content negotiation and Link rel=alter
 
 import pytest
 
-from pyld import DocumentLoader, jsonld
-from pyld.documentloader.aiohttp import AioHttpDocumentLoader
-from pyld.documentloader.requests import RequestsDocumentLoader
+from pyld import (
+    AioHttpDocumentLoader,
+    DocumentLoader,
+    RequestsDocumentLoader,
+    jsonld,
+)
 
 
 @pytest.mark.network
@@ -92,6 +95,14 @@ def test_aiohttp_document_loader_factory_returns_document_loader():
     assert isinstance(loader, AioHttpDocumentLoader)
     assert isinstance(loader, DocumentLoader)
     assert callable(loader)
+
+
+def test_built_in_document_loader_classes_are_top_level_exports():
+    """Built-in loader classes are public imports from pyld."""
+    pytest.importorskip("requests")
+    pytest.importorskip("aiohttp")
+    assert isinstance(RequestsDocumentLoader(), DocumentLoader)
+    assert isinstance(AioHttpDocumentLoader(), DocumentLoader)
 
 
 @pytest.mark.network

--- a/tests/test_document_loader.py
+++ b/tests/test_document_loader.py
@@ -10,7 +10,9 @@ Tests for document loaders: Accept header content negotiation and Link rel=alter
 
 import pytest
 
-from pyld import jsonld
+from pyld import DocumentLoader, jsonld
+from pyld.documentloader.aiohttp import AioHttpDocumentLoader
+from pyld.documentloader.requests import RequestsDocumentLoader
 
 
 @pytest.mark.network
@@ -72,6 +74,24 @@ _LOADERS = {
 def document_loader(request):
     """Parametrizing fixture: yields requests and aiohttp document loaders."""
     return _LOADERS[request.param]()
+
+
+def test_requests_document_loader_factory_returns_document_loader():
+    """Requests factory returns a class-based callable document loader."""
+    pytest.importorskip("requests")
+    loader = jsonld.requests_document_loader()
+    assert isinstance(loader, RequestsDocumentLoader)
+    assert isinstance(loader, DocumentLoader)
+    assert callable(loader)
+
+
+def test_aiohttp_document_loader_factory_returns_document_loader():
+    """Aiohttp factory returns a class-based callable document loader."""
+    pytest.importorskip("aiohttp")
+    loader = jsonld.aiohttp_document_loader()
+    assert isinstance(loader, AioHttpDocumentLoader)
+    assert isinstance(loader, DocumentLoader)
+    assert callable(loader)
 
 
 @pytest.mark.network


### PR DESCRIPTION
Closes #261

- Converts built-in requests and aiohttp document loaders to DocumentLoader subclasses while preserving factory call APIs.
- Adds factory tests for class-based loader instances.
- Ignores local .venv directories.