### PR TITLE
Add option to set MAX_CONTEXT_URLS in ContextResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   JSON-LD contexts (ActivityStreams, DID v1, VC v1/v2, Linked Data Security
   v1/v2, Ed25519-2020, JWS-2020) to vendored on-disk copies. Refresh with
   `make download-bundled-contexts`.
+- `pyld.ContextResolver`: added the `max_context_urls` property that 
+  determines maximum number of times contexts can be recusively fetched,
+  which replaces the role of the static `MAX_CONTEXT_URLS`. The constructor 
+  now accepts a `max_context_urls` parameter that sets the value of 
+  `max_context_urls` which defaults to `MAX_CONTEXT_URLS`. 
+
 
 ## 3.0.0 - 2026-04-02
 

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,67 @@ SHOULD attempt to use a locally cached version of contexts (see
 `§ Cache JSON-LD Contexts <https://w3c.github.io/json-ld-bp/#cache-json-ld-contexts>`_).
 Refresh the bundled copies with ``make download-bundled-contexts``.
 
+Customizing the ContextLoader
+-----------------------------
+
+You can customize the way contexts are loaded and cached by passing an instance
+of `ContextResolver`. The following example implements a loader with a 
+prefilled custom document cache and uses a custom LRU cache for resolved 
+contexts:
+
+.. code-block:: Python
+
+    from pyld.jsonld import compact, expand, set_document_loader, ContextResolver
+    import json
+    from cachetools import LRUCache
+
+    # Load the Linked Art context from file-system
+    fh = open('linked-art.json')
+    js = json.load(fh)
+    fh.close()
+
+    # Add to document cache
+    docCache = {
+        "https://linked.art/ns/v1/linked-art.json": {
+            "contextUrl": None,
+            "documentUrl": "https://linked.art/ns/v1/linked-art.json",
+            "document": js
+        }
+    }
+
+    # Custom loader that uses the document cache
+    def load_document_and_cache(url, options={}):
+        if url in docCache:
+            return docCache[url]
+        doc = {"contextUrl": None, "documentUrl": url, "document": ""}
+        resp = requests.get(url)
+        doc["document"] = resp.json()
+        docCache[url] = doc
+        return doc
+
+    # Set the custom loader as global document loader
+    set_document_loader(load_document_and_cache)
+    # Create custom context resolver with custom LRU cache and custom loader
+    resolved_context_cache = LRUCache(maxsize=1000)
+    resolver = ContextResolver(resolved_context_cache, load_document_and_cache)
+
+    # Expand JSON-LD document using custom context resolver
+    input = {"@context":"https://linked.art/ns/v1/linked-art.json", "id": "tag:foo", "type": "Person"}
+    output = expand(input, options={'contextResolver': resolver})
+
+
+It is also possible to change the maximum number of times that the loader recusively fetches contexts,
+by passing the `max_context_urls` parameter:
+
+.. code-block:: Python
+
+    resolver = ContextResolver(resolved_context_cache, load_document_and_cache, max_context_urls=20)
+    # Or you can do...
+    # resolver = ContextResolver(resolved_context_cache, load_document_and_cache)
+    # resolver.max_context_urls = 20
+    output = expand(input, options={'contextResolver': resolver})
+
+
 Handling ignored properties during JSON-LD expansion
 ----------------------------------------------------
 

--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -15,6 +15,7 @@ from pyld import iri_resolver, jsonld
 
 from .resolved_context import ResolvedContext
 
+# Restraints
 MAX_CONTEXT_URLS = 10
 
 
@@ -23,14 +24,28 @@ class ContextResolver:
     Resolves and caches remote contexts.
     """
 
-    def __init__(self, shared_cache, document_loader):
+    def __init__(self, shared_cache, document_loader, max_context_urls = None):
         """
         Creates a ContextResolver.
+
+        :param max_context_urls: the maximum number of times to recusively fetch contexts.
+          (default MAX_CONTEXT_URLS).
         """
         # processor-specific RDF parsers
         self.per_op_cache = {}
         self.shared_cache = shared_cache
         self.document_loader = document_loader
+        self._max_context_urls: int = max_context_urls if isinstance(max_context_urls, int) else MAX_CONTEXT_URLS
+
+    @property
+    def max_context_urls(self) -> int:
+        return self._max_context_urls
+
+    @max_context_urls.setter
+    def max_context_urls(self, max_context_urls: int) -> None:
+        if not isinstance(max_context_urls, int):
+            raise TypeError("Value for max_context_urls is not a number")
+        self._max_context_urls = max_context_urls
 
     def resolve(self, active_ctx, context, base, cycles=None):
         """
@@ -125,11 +140,11 @@ class ContextResolver:
 
     def _fetch_context(self, active_ctx, url, cycles):
         # check for max context URLs fetched during a resolve operation
-        if len(cycles) > MAX_CONTEXT_URLS:
+        if len(cycles) > self.max_context_urls:
             raise jsonld.JsonLdError(
                 'Maximum number of @context URLs exceeded.',
                 'jsonld.ContextUrlError',
-                {'max': MAX_CONTEXT_URLS},
+                {'max': self.max_context_urls},
                 code=(
                     'loading remote context failed'
                     if active_ctx.get('processingMode') == 'json-ld-1.0'

--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -35,7 +35,7 @@ class ContextResolver:
         self.per_op_cache = {}
         self.shared_cache = shared_cache
         self.document_loader = document_loader
-        self._max_context_urls: int = max_context_urls if isinstance(max_context_urls, int) else MAX_CONTEXT_URLS
+        self.max_context_urls: int = max_context_urls
 
     @property
     def max_context_urls(self) -> int:

--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -28,6 +28,8 @@ class ContextResolver:
         """
         Creates a ContextResolver.
 
+        :param shared_cache: the shared document cache.
+        :param document_loader: the document loader.
         :param max_context_urls: the maximum number of times to recusively fetch contexts.
           (default MAX_CONTEXT_URLS).
         """
@@ -37,16 +39,6 @@ class ContextResolver:
         self.document_loader = document_loader
         self.max_context_urls: int = max_context_urls
 
-    @property
-    def max_context_urls(self) -> int:
-        return self._max_context_urls
-
-    @max_context_urls.setter
-    def max_context_urls(self, max_context_urls: int) -> None:
-        if not isinstance(max_context_urls, int):
-            raise TypeError("Value for max_context_urls is not a number")
-        self._max_context_urls = max_context_urls
-
     def resolve(self, active_ctx, context, base, cycles=None):
         """
         Resolve a context.
@@ -54,8 +46,7 @@ class ContextResolver:
         :param active_ctx: the current active context.
         :param context: the context to resolve.
         :param base: the absolute URL to use for making url absolute.
-        :param cycles: the maximum number of times to recusively fetch contexts.
-          (default MAX_CONTEXT_URLS).
+        :param cycles: the set to store fetched contexts and detect cycles. (default None).
         """
         if cycles is None:
             cycles = set()

--- a/lib/pyld/context_resolver.py
+++ b/lib/pyld/context_resolver.py
@@ -24,7 +24,7 @@ class ContextResolver:
     Resolves and caches remote contexts.
     """
 
-    def __init__(self, shared_cache, document_loader, max_context_urls = None):
+    def __init__(self, shared_cache, document_loader, max_context_urls: int = MAX_CONTEXT_URLS):
         """
         Creates a ContextResolver.
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -127,9 +127,6 @@ LINK_HEADER_REL = JSON_LD_NS + 'context'
 # Default base IRI if none is provided through input or options
 DEFAULT_BASE_IRI = 'http://example.org/base/'
 
-# Restraints
-MAX_CONTEXT_URLS = 10
-
 # resolved context cache
 # TODO: consider basing max on context size rather than number
 RESOLVED_CONTEXT_CACHE_MAX_SIZE = 100


### PR DESCRIPTION
Fixes #104 

This would allow setting a custom ContextResolver with a different level, for instance 20:
```
contextresolver = ContextResolver(jsonld._resolved_context_cache, options['documentLoader'], max_context_urls=20)
jsonld.compact(input, context, {"contextResolver": contextresolver})
```

This is a ok fix, but the contextresolver could use a refactor. 
- The `cycles` parameter in `ContextResolver.resolve()` is a `set()`, but can also be an integer. 
- It feels like the default contextresolver should be part of the JsonLdProcessor object instead of being created in the method.
- according to the docs, "contextResolver" is "for internal use only", but I'm not sure why that is. @davidlehn @dlongley @BigBlueHat ?


