### PR TITLE
Utilize pytest output comparison for improved testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   class-based `DocumentLoader` instances while preserving the existing
   callable factory API. The concrete `RequestsDocumentLoader` and
   `AioHttpDocumentLoader` classes are also importable from `pyld`.
+- The `pytest` test runner now uses plain assert result == expect instead 
+  of printing EXPECTED / ACTUAL and raising a generic failure. This enables 
+  `pytests`'s native result comparison.
 
 ### Added
 - `pyld.DocumentLoader` abstract base class for class-based document loaders,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,12 @@ from contextlib import suppress
 
 import pytest
 
+# Register tests.runtests for pytest assertion rewriting before importing it.
+pytest.register_assert_rewrite('tests.runtests')
+
 # Import the existing test runner module so we can reuse Manifest/Test
 # implementations with minimal changes.
-from . import runtests
+from . import runtests  # noqa: E402
 
 
 def pytest_addoption(parser):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -470,31 +470,28 @@ class Test(unittest.TestCase):
                         'format': 'application/n-quads',
                     },
                 )
-                if result == expect:
-                    self.assertTrue(True)
+                if _running_under_pytest():
+                    assert result == expect
                 else:
-                    print('\nEXPECTED: ', expect)
-                    print('ACTUAL: ', result)
-                    raise AssertionError('results differ')
+                    assert_results_equal(result, expect)
             elif not self.is_negative:
                 # Perform order-independent equivalence test
-                if equal_unordered(result, expect):
-                    self.assertTrue(True)
-                else:
-                    print('\nEXPECTED: ', json.dumps(expect, indent=2))
-                    print('ACTUAL: ', json.dumps(result, indent=2))
-                    raise AssertionError('results differ')
+                if not equal_unordered(result, expect):
+                    if _running_under_pytest():
+                        assert result == expect
+                    else:
+                        assert_results_equal(result, expect, json_output=True)
             else:
-                self.assertEqual(result, expect)
+                if _running_under_pytest():
+                    assert result == expect
+                else:
+                    assert_results_equal(result, expect)
             if self.pending and not self.is_negative:
                 raise AssertionError('pending positive test passed')
         except AssertionError as e:
-            if e.args[0] == 'pending positive test passed':
-                print(e)
-                raise e
-            elif not self.is_negative and not self.pending:
-                print('\nEXPECTED: ', json.dumps(expect, indent=2))
-                print('ACTUAL: ', json.dumps(result, indent=2))
+            if (e.args and e.args[0] == 'pending positive test passed') or (
+                not self.is_negative and not self.pending
+            ):
                 raise e
             elif not self.is_negative or (self.is_negative and self.pending):
                 print('pending')
@@ -513,7 +510,23 @@ class Test(unittest.TestCase):
                 print('pending')
             else:
                 # import pdb; pdb.set_trace()
-                self.assertEqual(result, expect)
+                if _running_under_pytest():
+                    assert result == expect
+                else:
+                    assert_results_equal(result, expect)
+
+
+def assert_results_equal(result, expect, json_output=False):
+    if json_output:
+        expect = json.dumps(expect, indent=2)
+        result = json.dumps(result, indent=2)
+    print('\nEXPECTED: ', expect)
+    print('ACTUAL: ', result)
+    raise AssertionError('results differ')
+
+
+def _running_under_pytest():
+    return 'pytest' in sys.modules
 
 
 # Compare values with order-insensitive array tests


### PR DESCRIPTION
This PR improves the test runner output so it uses the native result comparison of pytest if available. I was getting annoyed about this unreadable ACTUAL/EXPECTED output when tests fail 😄 

The legacy test-runner still outputs the old logs though.