### PR TITLE
Add compound literal from RDF regression tests

### DIFF
--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -981,7 +981,7 @@ class TestFromRDF:
 
     def test_shared_compound_literal_blank_node_remains_node(self):
         """
-        Compound literal blank nodes must only be decoded when referenced once.
+        Compound literal blank nodes must only be decoded once when referenced.
         """
         input = """
         <http://example.com/a> <http://example.org/label> _:cl1 .

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -979,6 +979,72 @@ class TestFromRDF:
 
         assert result == expected
 
+    def test_shared_compound_literal_blank_node_remains_node(self):
+        """
+        Compound literal blank nodes must only be decoded when referenced once.
+        """
+        input = """
+        <http://example.com/a> <http://example.org/label> _:cl1 .
+        <http://example.com/b> <http://example.org/label> _:cl1 .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "shared" .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#direction> "rtl" .
+        """
+
+        expected = [
+            {
+                '@id': '_:cl1',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#direction': [
+                    {'@value': 'rtl'}
+                ],
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#value': [
+                    {'@value': 'shared'}
+                ],
+            },
+            {
+                '@id': 'http://example.com/a',
+                'http://example.org/label': [{'@id': '_:cl1'}],
+            },
+            {
+                '@id': 'http://example.com/b',
+                'http://example.org/label': [{'@id': '_:cl1'}],
+            },
+        ]
+
+        result = jsonld.from_rdf(input, {'rdfDirection': 'compound-literal'})
+
+        assert result == expected
+
+    def test_compound_literal_invalid_direction_fails(self):
+        """
+        Invalid rdf:direction values in compound literals must fail.
+        """
+        input = """
+        <http://example.com/a> <http://example.org/label> _:cl1 .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "bad" .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#direction> "up" .
+        """
+
+        with pytest.raises(jsonld.JsonLdError) as exc:
+            jsonld.from_rdf(input, {'rdfDirection': 'compound-literal'})
+
+        assert exc.value.code == 'invalid base direction'
+
+    def test_compound_literal_invalid_language_fails(self):
+        """
+        Invalid rdf:language values in compound literals must fail.
+        """
+        input = """
+        <http://example.com/a> <http://example.org/label> _:cl1 .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "bad lang" .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#language> "bad_lang" .
+        _:cl1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#direction> "rtl" .
+        """
+
+        with pytest.raises(jsonld.JsonLdError) as exc:
+            jsonld.from_rdf(input, {'rdfDirection': 'compound-literal'})
+
+        assert exc.value.code == 'invalid language-tagged string'
+
 class TestCompact:
     # Issue 59 - PR: https://github.com/digitalbazaar/pyld/pull/60
     def test_compaction_with_and_without_explicit_datatypes(self):


### PR DESCRIPTION
- shared compound-literal blank nodes must remain ordinary nodes when referenced more than once
- invalid rdf:direction values must raise invalid base direction
- invalid rdf:language values must raise invalid language-tagged string

These tests currently fail against the implementation in #270 and are intended to document the expected behavior before the implementation is adjusted.