### PR TITLE
Add support for compound literals in JSON-LD to RDF with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,12 @@
   which replaces the role of the static `MAX_CONTEXT_URLS`. The constructor 
   now accepts a `max_context_urls` parameter that sets the value of 
   `max_context_urls` which defaults to `MAX_CONTEXT_URLS`. 
-- `pyld.fromRdf()` now supports compound literals when serializing RDF to JSON-LD. 
-  It therefore also accepts the value `'compound-literal'` for the `'rdfDirection'` option. 
-  Fixes [fromRdf#tdi11](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi11) 
-  and [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12).
+- `pyld.fromRdf()` and `pyld.toRdf()` now support compound literals when serializing RDF to JSON-LD. 
+  Therefore, both methods accept the value `'compound-literal'` for the `'rdfDirection'` option. 
+  Fixes [fromRdf#tdi11](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi11),
+  [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12),
+  [toRdf#tdi11](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi11), and
+  [toRdf#tdi12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi12).
 
 ## 3.0.0 - 2026-04-02
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -1057,7 +1057,7 @@ class JsonLdProcessor:
             to produce only standard RDF (default: false).
           [documentLoader(url, options)] the document loader
             (default: _default_document_loader).
-          [rdfDirection] Only 'i18n-datatype' supported
+          [rdfDirection] Either 'i18n-datatype' or 'compound-literal'
             (default: None).
 
         :return: the resulting RDF dataset (or a serialization of it).
@@ -3917,8 +3917,7 @@ class JsonLdProcessor:
         :param item: the JSON-LD value or node object.
         :param issuer: the IdentifierIssuer for issuing blank node identifiers.
         :param triples: the array of triples to append list entries to.
-        :param rdf_direction: for creating datatyped literals.
-        :param rdf_direction: for creating datatyped literals.
+        :param rdf_direction: for creating directional literals.
 
         :return: the RDF literal or RDF resource.
         """
@@ -3960,6 +3959,44 @@ class JsonLdProcessor:
             elif _is_integer(value):
                 object['value'] = str(value)
                 object['datatype'] = datatype or XSD_INTEGER
+            elif rdf_direction == 'compound-literal' and '@direction' in item:
+                object['type'] = 'blank node'
+                object['value'] = issuer.get_id()
+                subject = {'type': 'blank node', 'value': object['value']}
+                triples.append(
+                    {
+                        'subject': subject,
+                        'predicate': {'type': 'IRI', 'value': RDF_VALUE},
+                        'object': {
+                            'type': 'literal',
+                            'value': value,
+                            'datatype': XSD_STRING,
+                        },
+                    }
+                )
+                triples.append(
+                    {
+                        'subject': subject,
+                        'predicate': {'type': 'IRI', 'value': RDF_DIRECTION},
+                        'object': {
+                            'type': 'literal',
+                            'value': item['@direction'],
+                            'datatype': XSD_STRING,
+                        },
+                    }
+                )
+                if '@language' in item:
+                    triples.append(
+                        {
+                            'subject': subject,
+                            'predicate': {'type': 'IRI', 'value': RDF_LANGUAGE},
+                            'object': {
+                                'type': 'literal',
+                                'value': item['@language'],
+                                'datatype': XSD_STRING,
+                            },
+                        }
+                    )
             elif rdf_direction == 'i18n-datatype' and '@direction' in item:
                 datatype = 'https://www.w3.org/ns/i18n#{}_{}'.format(
                     item.get('@language', ''), item['@direction']

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1037,11 +1037,7 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # node object direction
-                '.*toRdf-manifest#tdi11$',
-                '.*toRdf-manifest#tdi12$',
-            ],
+            'idRegex': [],
         },
         'fn': 'to_rdf',
         'params': [

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -872,6 +872,62 @@ class TestToRdf:
         result = jsonld.to_rdf(input)
         assert result == expected
 
+    def test_compound_literal_direction_without_language(self):
+        """
+        Values with @direction should become compound literals during to_rdf
+        when rdfDirection is compound-literal.
+        """
+        input = {
+            'http://example.org/label': {
+                '@value': 'no language',
+                '@direction': 'rtl',
+            }
+        }
+
+        expected = """_:b0 <http://example.org/label> _:b1 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#direction> "rtl" .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "no language" .
+"""
+
+        nquads = jsonld.to_rdf(
+            input,
+            options={
+                'format': 'application/n-quads',
+                'rdfDirection': 'compound-literal',
+            },
+        )
+
+        assert nquads == expected
+
+    def test_compound_literal_direction_with_language(self):
+        """
+        Values with @language should preserve it in compound literals during
+        to_rdf when rdfDirection is compound-literal.
+        """
+        input = {
+            'http://example.org/label': {
+                '@value': 'en-US',
+                '@language': 'en-US',
+                '@direction': 'rtl',
+            }
+        }
+
+        expected = """_:b0 <http://example.org/label> _:b1 .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#direction> "rtl" .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#language> "en-us" .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "en-US" .
+"""
+
+        nquads = jsonld.to_rdf(
+            input,
+            options={
+                'format': 'application/n-quads',
+                'rdfDirection': 'compound-literal',
+            },
+        )
+
+        assert nquads == expected
+
      # Issue 204
     def test_conflicting_property_names(self):
         """


### PR DESCRIPTION
This PR extends support for compound literals to JSON-LD to RDF conversion (`toRdf()`). 
It fixes [toRdf#tdi11](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi11) (Generates i18n datatype from literal with direction with option.) and [toRdf#tdi12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi12) (Generates compound literal from literal with direction with option.).