### PR TITLE
Throw error for invalid @type values in @value elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.2.0 - unreleased
 
+### Fixed
+- Throws an error if value objects contain array values for `@type` during expansion. Fixes [expand#ter54](https://w3c.github.io/json-ld-api/tests/expand-manifest.html#ter54) and [toRdf#ter54](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ter54).
+- When using native types, values of `xsd:boolean` and `xsd:integer` are now properly converted. Fixes [fromRdf#t0027](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#t0027).
+
 ## 3.1.0 - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,10 +71,6 @@
   [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12),
   [toRdf#tdi11](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi11), and
   [toRdf#tdi12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi12).
-- `pyld.fromRdf()` now supports compound literals when serializing RDF to JSON-LD. 
-  It therefore also accepts the value `'compound-literal'` for the `'rdfDirection'` option. 
-  Fixes [fromRdf#tdi11](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi11) 
-  and [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12).
 
 ## 3.0.0 - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12),
   [toRdf#tdi11](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi11), and
   [toRdf#tdi12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#tdi12).
+- `pyld.fromRdf()` now supports compound literals when serializing RDF to JSON-LD. 
+  It therefore also accepts the value `'compound-literal'` for the `'rdfDirection'` option. 
+  Fixes [fromRdf#tdi11](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi11) 
+  and [fromRdf#tdi12](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#tdi12).
 
 ## 3.0.0 - 2026-04-02
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -18,6 +18,7 @@ JSON-LD.
 
 import copy
 import json
+import math
 import re
 import sys
 import uuid
@@ -35,7 +36,12 @@ from c14n.Canonicalize import canonicalize
 from pyld.__about__ import __copyright__, __license__, __version__
 from pyld.canon import URDNA2015, URGNA2012, UnknownFormatError
 from pyld.identifier_issuer import IdentifierIssuer
-from pyld.nquads import ParserError, parse_nquads, serialize_nquad, serialize_nquads
+from pyld.nquads import (
+    ParserError,
+    parse_nquads,
+    serialize_nquad,
+    serialize_nquads,
+)
 
 from .context_resolver import ContextResolver
 from .iri_resolver import resolve, unresolve
@@ -4113,19 +4119,24 @@ class JsonLdProcessor:
 
             # use native types for certain xsd types
             if use_native_types:
+                converted = False
                 if type_ == XSD_BOOLEAN:
-                    if rval['@value'] == 'true':
+                    if rval['@value'] in ['true', '1']:
                         rval['@value'] = True
-                    elif rval['@value'] == 'false':
+                        converted = True
+                    elif rval['@value'] in ['false', '0']:
                         rval['@value'] = False
-                elif _is_numeric(rval['@value']):
-                    if type_ == XSD_INTEGER:
-                        if rval['@value'].isdigit():
-                            rval['@value'] = int(rval['@value'])
-                    elif type_ == XSD_DOUBLE:
-                        rval['@value'] = float(rval['@value'])
+                        converted = True
+                elif type_ == XSD_INTEGER and re.match(r'^[+-]?\d+$', rval['@value']):
+                    rval['@value'] = int(rval['@value'])
+                    converted = True
+                elif type_ == XSD_DOUBLE and _is_numeric(rval['@value']):
+                    value = float(rval['@value'])
+                    if math.isfinite(value):
+                        rval['@value'] = value
+                        converted = True
                 # do not add native type
-                if type_ not in [XSD_BOOLEAN, XSD_INTEGER, XSD_DOUBLE, XSD_STRING]:
+                if not converted and type_ != XSD_STRING:
                     rval['@type'] = type_
             elif rdf_direction == 'i18n-datatype' and type_.startswith(
                 'https://www.w3.org/ns/i18n#'

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -2418,15 +2418,12 @@ class JsonLdProcessor:
                             code='invalid @id value',
                         )
 
-                expanded_values = []
-                for v in JsonLdProcessor.arrayify(value):
-                    expanded_values.append(
-                        v
-                        if _is_object(v)
-                        else self._expand_iri(
-                            active_ctx, v, base=options.get('base', '')
-                        )
-                    )
+                expanded_values = [
+                    v
+                    if _is_object(v)
+                    else self._expand_iri(active_ctx, v, base=options.get('base', ''))
+                    for v in JsonLdProcessor.arrayify(value)
+                ]
 
                 JsonLdProcessor.add_value(
                     expanded_parent,
@@ -2448,10 +2445,8 @@ class JsonLdProcessor:
                 if _is_object(value):
                     # if framing, can be a default object, but need to expand
                     # key to determine that
-                    new_value = {}
-                    for k, v in value.items():
-                        ek = self._expand_iri(type_scoped_ctx, k, vocab=True)
-                        ev = [
+                    value = {
+                        self._expand_iri(type_scoped_ctx, k, vocab=True): [
                             self._expand_iri(
                                 type_scoped_ctx,
                                 vv,
@@ -2460,20 +2455,19 @@ class JsonLdProcessor:
                             )
                             for vv in JsonLdProcessor.arrayify(v)
                         ]
-                        new_value[ek] = ev
-                    value = new_value
+                        for k, v in value.items()
+                    }
                 else:
                     value = JsonLdProcessor.arrayify(value)
                 _validate_type_value(value, options.get('isFrame'))
-                expanded_values = []
-                for v in JsonLdProcessor.arrayify(value):
-                    expanded_values.append(
-                        self._expand_iri(
-                            type_scoped_ctx, v, vocab=True, base=options.get('base', '')
-                        )
-                        if _is_string(v)
-                        else v
+                expanded_values = [
+                    self._expand_iri(
+                        type_scoped_ctx, v, vocab=True, base=options.get('base', '')
                     )
+                    if _is_string(v)
+                    else v
+                    for v in JsonLdProcessor.arrayify(value)
+                ]
                 JsonLdProcessor.add_value(
                     expanded_parent,
                     '@type',
@@ -2547,9 +2541,10 @@ class JsonLdProcessor:
                         code='invalid language-tagged string',
                     )
                 # ensure language value is lowercase
-                expanded_values = []
-                for v in JsonLdProcessor.arrayify(value):
-                    expanded_values.append(v.lower() if _is_string(v) else v)
+                expanded_values = [
+                    v.lower() if _is_string(v) else v
+                    for v in JsonLdProcessor.arrayify(value)
+                ]
                 JsonLdProcessor.add_value(
                     expanded_parent,
                     '@language',
@@ -2568,14 +2563,13 @@ class JsonLdProcessor:
                         code='invalid base direction',
                     )
                 value = JsonLdProcessor.arrayify(value)
-                for dir in value:
-                    if _is_string(dir) and dir != 'ltr' and dir != 'rtl':
-                        raise JsonLdError(
-                            'Invalid JSON-LD syntax; "@direction" must be "ltr" or "rtl".',
-                            'jsonld.SyntaxError',
-                            {'value': value},
-                            code='invalid base direction',
-                        )
+                if any(_is_string(dir) and dir not in ('ltr', 'rtl') for dir in value):
+                    raise JsonLdError(
+                        'Invalid JSON-LD syntax; "@direction" must be "ltr" or "rtl".',
+                        'jsonld.SyntaxError',
+                        {'value': value},
+                        code='invalid base direction',
+                    )
                 JsonLdProcessor.add_value(
                     expanded_parent,
                     '@direction',
@@ -2670,7 +2664,6 @@ class JsonLdProcessor:
                 expanded_value = self._expand_language_map(term_ctx, value, direction)
             # handle index container (skip if value is not an object)
             elif '@index' in container and _is_object(value):
-                as_graph = '@graph' in container
                 index_key = JsonLdProcessor.get_context_value(term_ctx, key, '@index')
                 if index_key is None:
                     index_key = '@index'
@@ -2680,12 +2673,17 @@ class JsonLdProcessor:
                         active_ctx, index_key, vocab=options.get('base', '')
                     )
                 expanded_value = self._expand_index_map(
-                    term_ctx, key, value, index_key, as_graph, property_index, options
+                    term_ctx,
+                    key,
+                    value,
+                    index_key,
+                    '@graph' in container,
+                    property_index,
+                    options,
                 )
             elif '@id' in container and _is_object(value):
-                as_graph = '@graph' in container
                 expanded_value = self._expand_index_map(
-                    term_ctx, key, value, '@id', as_graph, None, options
+                    term_ctx, key, value, '@id', '@graph' in container, None, options
                 )
             elif '@type' in container and _is_object(value):
                 expanded_value = self._expand_index_map(
@@ -2782,23 +2780,22 @@ class JsonLdProcessor:
 
         # @value must not be an object or an array (unless framing)
         # or if @type is @json
-        if '@value' in expanded_parent:
-            if expanded_parent.get('@type') == '@json' and self._processing_mode(
-                active_ctx, 1.1
-            ):
-                # allow any value, to be verified when the object
-                # is fully expanded and the @type is @json.
-                pass
-            elif (
-                _is_object(unexpanded_value) or _is_array(unexpanded_value)
-            ) and not options['isFrame']:
-                raise JsonLdError(
-                    'Invalid JSON-LD syntax; @value" value must not be an '
-                    'object or an array.',
-                    'jsonld.SyntaxError',
-                    {'value': unexpanded_value},
-                    code='invalid value object value',
-                )
+        if (
+            '@value' in expanded_parent
+            and not (
+                expanded_parent.get('@type') == '@json'
+                and self._processing_mode(active_ctx, 1.1)
+            )
+            and (_is_object(unexpanded_value) or _is_array(unexpanded_value))
+            and not options['isFrame']
+        ):
+            raise JsonLdError(
+                'Invalid JSON-LD syntax; @value" value must not be an '
+                'object or an array.',
+                'jsonld.SyntaxError',
+                {'value': unexpanded_value},
+                code='invalid value object value',
+            )
 
         # Nested values merge into the current node, but their term and type
         # scoped contexts must still be prepared as if expanding a node object.
@@ -2817,11 +2814,10 @@ class JsonLdProcessor:
                     term_ctx, nv, options
                 )
 
-                if [
-                    k
-                    for k, v in nv.items()
-                    if self._expand_iri(active_ctx, k, vocab=True) == '@value'
-                ]:
+                if any(
+                    self._expand_iri(active_ctx, k, vocab=True) == '@value'
+                    for k in nv
+                ):
                     raise JsonLdError(
                         'Invalid JSON-LD syntax; nested value must be a node object.',
                         'jsonld.SyntaxError',

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -2207,6 +2207,22 @@ class JsonLdProcessor:
                     code='invalid value object',
                 )
 
+            if '@type' in rval:
+                if not options.get('isFrame') and any(
+                    self._expand_iri(active_ctx, key, vocab=True) == '@type'
+                    and _is_array(value)
+                    for key, value in element.items()
+                ):
+                    raise JsonLdError(
+                        'Invalid JSON-LD syntax; an element containing "@value" '
+                        'must have a string or null value for "@type".',
+                        'jsonld.SyntaxError',
+                        {'element': rval},
+                        code='invalid typed value',
+                    )
+                if rval['@type'] is None:
+                    del rval['@type']
+
             values = JsonLdProcessor.get_values(rval, '@value')
             types = JsonLdProcessor.get_values(rval, '@type')
 
@@ -2246,8 +2262,17 @@ class JsonLdProcessor:
                     code='invalid typed value',
                 )
         # convert @type to an array
-        elif '@type' in rval and not _is_array(rval['@type']):
-            rval['@type'] = [rval['@type']]
+        elif '@type' in rval:
+            if rval['@type'] is None:
+                raise JsonLdError(
+                    'Invalid JSON-LD syntax; "@type" value must be a string, '
+                    'an array of strings, or an empty object.',
+                    'jsonld.SyntaxError',
+                    {'value': None},
+                    code='invalid type value',
+                )
+            if not _is_array(rval['@type']):
+                rval['@type'] = [rval['@type']]
         # handle @set and @list
         elif '@set' in rval or '@list' in rval:
             if count > 1 and not (count == 2 and '@index' in rval):
@@ -2412,6 +2437,14 @@ class JsonLdProcessor:
                 continue
 
             if expanded_property == '@type':
+                if value is None:
+                    JsonLdProcessor.add_value(
+                        expanded_parent,
+                        '@type',
+                        None,
+                        {'propertyIsArray': options['isFrame']},
+                    )
+                    continue
                 if _is_object(value):
                     # if framing, can be a default object, but need to expand
                     # key to determine that

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -991,10 +991,7 @@ TEST_TYPES = {
     'jld:FromRDFTest': {
         'skip': {
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # uncategorized
-                '.*fromRdf-manifest#t0027$',
-            ],
+            'idRegex': [],
         },
         'fn': 'from_rdf',
         'params': [

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -952,7 +952,6 @@ TEST_TYPES = {
             'specVersion': ['json-ld-1.0'],
             'idRegex': [
                 # uncategorized
-                '.*expand-manifest#ter54$',
                 '.*expand-manifest#ter56$',
             ],
         },
@@ -1027,7 +1026,6 @@ TEST_TYPES = {
                 # well formed
                 '.*toRdf-manifest#twf05$',
                 # uncategorized
-                '.*toRdf-manifest#ter54$',
                 '.*toRdf-manifest#ter56$',
                 '.*toRdf-manifest#tli12$',
                 '.*toRdf-manifest#tli14$',

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -92,6 +92,33 @@ class TestExpand:
         assert got == []
         assert dropped_keys == {"fooo"}
 
+    def test_value_object_type_array_fails(self):
+        """
+        Value objects must not allow array values for @type during expansion.
+        """
+        input = {
+            "@context": {"ex": "http://example.com/"},
+            "ex:prop": {"@value": "value", "@type": ["ex:a", "ex:b"]},
+        }
+
+        with pytest.raises(jsonld.JsonLdError) as exc:
+            jsonld.expand(input)
+
+        assert exc.value.code == 'invalid typed value'
+
+    def test_value_object_type_null_expands(self):
+        """
+        Value objects with @type set to null should expand without @type.
+        """
+        input = {
+            "@context": {"ex": "http://example.com/"},
+            "ex:prop": {"@value": "value", "@type": None},
+        }
+
+        assert jsonld.expand(input) == [
+            {"http://example.com/prop": [{"@value": "value"}]}
+        ]
+
     def test_dropped_keys_complex(self):
         """
         Complex example with keys not in the context should correctly store


### PR DESCRIPTION
Fixes tests 

- https://w3c.github.io/json-ld-api/tests/expand-manifest.html#ter54:
- https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ter54

> The value of @type in a value object MUST be a string or null.


The fix adds specific checks for `@type` in `@value` and validates its value. Throws error if it.s an array.
I also took the liberty of cleaning up some loops, mostly by turning them into list comprehension.