### PR TITLE
Format docs front page examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,49 +22,49 @@ and JSON document stores.
     Compacts a JSON-LD document with a context, replacing full IRIs with shorter
     terms where possible.
 
-    {{ example('compact.py', 'json') }}
+    {{ example('compact.py', 'json', indent=4) }}
 
 === "jsonld.expand()"
 
     Expands a compacted JSON-LD document into full IRI-based form and removes the
     context.
 
-    {{ example('expand.py', 'json') }}
+    {{ example('expand.py', 'json', indent=4) }}
 
 === "jsonld.flatten()"
 
     Flattens nested JSON-LD into a top-level node map so each node can be processed
     independently.
 
-    {{ example('flatten.py', 'json') }}
+    {{ example('flatten.py', 'json', indent=4) }}
 
 === "jsonld.frame()"
 
     Frames expanded JSON-LD into a predictable tree shape that matches a supplied
     frame.
 
-    {{ example('frame.py', 'json') }}
+    {{ example('frame.py', 'json', indent=4) }}
 
 === "jsonld.to_rdf()"
 
     Converts a JSON-LD document into RDF statements in a requested serialization
     format.
 
-    {{ example('to_rdf.py') }}
+    {{ example('to_rdf.py', indent=4) }}
 
 === "jsonld.from_rdf()"
 
     Converts RDF statements into JSON-LD so the data can be processed with the
     JSON-LD API.
 
-    {{ example('from_rdf.py', 'json') }}
+    {{ example('from_rdf.py', 'json', indent=4) }}
 
 === "jsonld.normalize()"
 
     Normalizes JSON-LD into canonical RDF statements for stable comparison,
     hashing, or signing.
 
-    {{ example('normalize.py') }}
+    {{ example('normalize.py', indent=4) }}
 
 ## :fontawesome-solid-people-line: Maintainers
 

--- a/docs_macros.py
+++ b/docs_macros.py
@@ -203,7 +203,7 @@ def define_env(env):
         return '\n'.join(rows)
 
     @env.macro
-    def example(name, output_syntax=None):
+    def example(name, output_syntax=None, indent=0):
         path = _example_path(name)
         source = path.read_text()
         result = subprocess.run(
@@ -226,5 +226,7 @@ def define_env(env):
             f'```python\n{source}```\n\n'
             f'```{output_lang} title="Output"\n{result.stdout}```'
         )
-        indented = '\n'.join(f'    {line}' for line in body.splitlines())
+        content_indent = indent + 4
+        pad = ' ' * content_indent
+        indented = '\n'.join(f'{pad}{line}' for line in body.splitlines())
         return f'!!! example "{title}"\n\n{indented}\n'


### PR DESCRIPTION
## Summary

- Add an `indent` parameter to the `example()` docs macro so admonition body content can be indented correctly when nested inside content tabs.
- Pass `indent=4` for all Quick Examples on the docs front page so input and output code blocks render inside the Example admonition.

## Test plan

- [x] `mkdocs build --strict` passes
- [x] Quick Examples tabs on the front page show code inside the Example admonition
- [x] Document loader pages without `indent` are unchanged