### PR TITLE
Document JSON-LD API functions with TypedDict options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) for code style, linting (e.g. `make lint
 - Do not use or mention function-based document loaders (`requests_document_loader`, `aiohttp_document_loader`, or plain callables) in docs; use `*DocumentLoader` classes or a `DocumentLoader` subclass.
 - Doc page H1 headers should use icons that match their card icons (e.g. `# :material-cloud-download: \`RequestsDocumentLoader\``).
 - Custom document-loader docs should illustrate subclassing `DocumentLoader`, not a bare callable.
+- JSON-LD API reference pages use **function autodoc + matching `*Options` TypedDict autodoc** under a `## Options` heading. Option key prose lives on the TypedDict fields in `lib/pyld/options.py`, not in nested `:param options:` continuations on the function docstring. TypedDict types are typing/documentation only — no runtime validation of `options` dicts.
+- Reference pages omit duplicate prose: set `show_docstring_description: false` on **function** autodoc blocks only. On `*Options` blocks use `show_bases: false` but keep descriptions enabled so field docstrings render. Do not use Sphinx `:func:` roles in TypedDict docstrings (they render literally). Wrap literals in single backticks (e.g. `True`, `False`).
+
+### Documentation validation
+
+- **No in-repo Playwright.** Do not add `@playwright/test`, `playwright.config.js`, or e2e test dependencies. Live browser checks use **only** the Playwright MCP server (`user-playwright`).
+- After doc changes, run `make docs-build` (strict). For interactive checks, run `make docs-serve` and validate with Playwright MCP: `browser_navigate`, `browser_snapshot`, `browser_click`, `browser_wait_for`. Prefer `browser_run_code_unsafe` with `page.screenshot({ animations: 'disabled', timeout: 60000 })` over `browser_take_screenshot` (font load timeouts).
 
 ## Committing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.2.0 - unreleased
 
+### Added
+- `*Options` TypedDict types and a `Context` type alias in `pyld.options` for JSON-LD API option dicts (typing and documentation).
+
 ### Fixed
 - Throws an error if value objects contain array values for `@type` during expansion. Fixes [expand#ter54](https://w3c.github.io/json-ld-api/tests/expand-manifest.html#ter54) and [toRdf#ter54](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ter54).
 - When using native types, values of `xsd:boolean` and `xsd:integer` are now properly converted. Fixes [fromRdf#t0027](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#t0027).

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ test:
 
 docs-install:
 	python -m pip install --upgrade pip
+	pip install -e .
 	pip install -r docs/requirements.txt
 
 docs-build:

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,49 +20,49 @@ and JSON document stores.
 === "jsonld.compact()"
 
     Compacts a JSON-LD document with a context, replacing full IRIs with shorter
-    terms where possible.
+    terms where possible. [Read more :octicons-arrow-right-24:](reference/compact.md)
 
     {{ example('compact.py', 'json', indent=4) }}
 
 === "jsonld.expand()"
 
     Expands a compacted JSON-LD document into full IRI-based form and removes the
-    context.
+    context. [Read more :octicons-arrow-right-24:](reference/expand.md)
 
     {{ example('expand.py', 'json', indent=4) }}
 
 === "jsonld.flatten()"
 
     Flattens nested JSON-LD into a top-level node map so each node can be processed
-    independently.
+    independently. [Read more :octicons-arrow-right-24:](reference/flatten.md)
 
     {{ example('flatten.py', 'json', indent=4) }}
 
 === "jsonld.frame()"
 
     Frames expanded JSON-LD into a predictable tree shape that matches a supplied
-    frame.
+    frame. [Read more :octicons-arrow-right-24:](reference/frame.md)
 
     {{ example('frame.py', 'json', indent=4) }}
 
 === "jsonld.to_rdf()"
 
     Converts a JSON-LD document into RDF statements in a requested serialization
-    format.
+    format. [Read more :octicons-arrow-right-24:](reference/to_rdf.md)
 
     {{ example('to_rdf.py', indent=4) }}
 
 === "jsonld.from_rdf()"
 
     Converts RDF statements into JSON-LD so the data can be processed with the
-    JSON-LD API.
+    JSON-LD API. [Read more :octicons-arrow-right-24:](reference/from_rdf.md)
 
     {{ example('from_rdf.py', 'json', indent=4) }}
 
 === "jsonld.normalize()"
 
     Normalizes JSON-LD into canonical RDF statements for stable comparison,
-    hashing, or signing.
+    hashing, or signing. [Read more :octicons-arrow-right-24:](reference/normalize.md)
 
     {{ example('normalize.py', indent=4) }}
 

--- a/docs/reference/compact.md
+++ b/docs/reference/compact.md
@@ -1,0 +1,17 @@
+# :material-arrow-collapse: `jsonld.compact()`
+
+::: pyld.jsonld.compact
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.CompactOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('compact.py', 'json') }}

--- a/docs/reference/expand.md
+++ b/docs/reference/expand.md
@@ -1,0 +1,17 @@
+# :material-arrow-expand: `jsonld.expand()`
+
+::: pyld.jsonld.expand
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.ExpandOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('expand.py', 'json') }}

--- a/docs/reference/flatten.md
+++ b/docs/reference/flatten.md
@@ -1,0 +1,17 @@
+# :material-layers-outline: `jsonld.flatten()`
+
+::: pyld.jsonld.flatten
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.FlattenOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('flatten.py', 'json') }}

--- a/docs/reference/frame.md
+++ b/docs/reference/frame.md
@@ -1,0 +1,17 @@
+# :material-view-dashboard-outline: `jsonld.frame()`
+
+::: pyld.jsonld.frame
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.FrameOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('frame.py', 'json') }}

--- a/docs/reference/from_rdf.md
+++ b/docs/reference/from_rdf.md
@@ -1,0 +1,17 @@
+# :material-import: `jsonld.from_rdf()`
+
+::: pyld.jsonld.from_rdf
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.FromRdfOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('from_rdf.py', 'json') }}

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,6 +6,61 @@ hide: [toc]
 
 <div class="grid cards" markdown>
 
+-   [:material-arrow-collapse:{ .lg .middle } `jsonld.compact()`](compact.md)
+
+    ---
+
+    Compacts a JSON-LD document with a context, replacing full IRIs with shorter
+    terms where possible.
+
+-   [:material-arrow-expand:{ .lg .middle } `jsonld.expand()`](expand.md)
+
+    ---
+
+    Expands a compacted JSON-LD document into full IRI-based form and removes the
+    context.
+
+-   [:material-layers-outline:{ .lg .middle } `jsonld.flatten()`](flatten.md)
+
+    ---
+
+    Flattens nested JSON-LD into a top-level node map so each node can be processed
+    independently.
+
+-   [:material-view-dashboard-outline:{ .lg .middle } `jsonld.frame()`](frame.md)
+
+    ---
+
+    Frames expanded JSON-LD into a predictable tree shape that matches a supplied
+    frame.
+
+-   [:material-export:{ .lg .middle } `jsonld.to_rdf()`](to_rdf.md)
+
+    ---
+
+    Converts a JSON-LD document into RDF statements in a requested serialization
+    format.
+
+-   [:material-import:{ .lg .middle } `jsonld.from_rdf()`](from_rdf.md)
+
+    ---
+
+    Converts RDF statements into JSON-LD so the data can be processed with the
+    JSON-LD API.
+
+-   [:material-fingerprint:{ .lg .middle } `jsonld.normalize()`](normalize.md)
+
+    ---
+
+    Normalizes JSON-LD into canonical RDF statements for stable comparison,
+    hashing, or signing.
+
+</div>
+
+## Also
+
+<div class="grid cards" markdown>
+
 -   [:material-file-download-outline:{ .lg .middle } __Document Loaders__](document-loaders/index.md)
 
     ---

--- a/docs/reference/normalize.md
+++ b/docs/reference/normalize.md
@@ -1,0 +1,17 @@
+# :material-fingerprint: `jsonld.normalize()`
+
+::: pyld.jsonld.normalize
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.NormalizeOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('normalize.py') }}

--- a/docs/reference/to_rdf.md
+++ b/docs/reference/to_rdf.md
@@ -1,0 +1,17 @@
+# :material-export: `jsonld.to_rdf()`
+
+::: pyld.jsonld.to_rdf
+    options:
+      show_docstring_description: false
+
+## Options
+
+::: pyld.options.ToRdfOptions
+    options:
+      show_root_heading: false
+      show_bases: false
+      heading_level: 3
+
+## Example
+
+{{ example('to_rdf.py') }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ typing_extensions
 mkdocs-material==9.7.6
 mkdocs-macros-plugin==1.5.0
 mkdocs-awesome-pages-plugin==2.10.1
+mkdocstrings[python]>=0.30

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -45,11 +45,29 @@ from pyld.nquads import (
 
 from .context_resolver import ContextResolver
 from .iri_resolver import resolve, unresolve
+from .options import (
+    CompactOptions,
+    Context,
+    ExpandOptions,
+    FlattenOptions,
+    FrameOptions,
+    FromRdfOptions,
+    NormalizeOptions,
+    ToRdfOptions,
+)
 
 __all__ = [
     '__copyright__',
     '__license__',
     '__version__',
+    'CompactOptions',
+    'Context',
+    'ExpandOptions',
+    'FlattenOptions',
+    'FrameOptions',
+    'FromRdfOptions',
+    'NormalizeOptions',
+    'ToRdfOptions',
     'compact',
     'expand',
     'flatten',
@@ -156,47 +174,30 @@ def noop(*args, **kwargs):
     return None
 
 
-def compact(input_, ctx, options=None):
+def compact(input_, ctx: Context, options: CompactOptions | None = None):
     """
     Performs JSON-LD compaction.
 
     :param input_: the JSON-LD input to compact.
     :param ctx: the JSON-LD context to compact with.
-    :param [options]: the options to use.
-      [base] the base IRI to use.
-      [compactArrays] True to compact arrays to single values when
-        appropriate, False not to (default: True).
-      [graph] True to always output a top-level graph (default: False).
-      [expandContext] a context to expand with.
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: False).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        defaults to 'json-ld-1.1'.
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
+    :param options: optional processing options; see Options below.
 
     :return: the compacted JSON-LD output.
     """
     return JsonLdProcessor().compact(input_, ctx, options)
 
 
-def expand(input_, options=None, on_property_dropped: OnPropertyDropped = noop):
+def expand(
+    input_,
+    options: ExpandOptions | None = None,
+    on_property_dropped: OnPropertyDropped = noop,
+):
     """
     Performs JSON-LD expansion.
 
     :param input_: the JSON-LD input to expand.
-    :param [options]: the options to use.
-      [base] the base IRI to use.
-      [expandContext] a context to expand with.
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: False).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        defaults to 'json-ld-1.1'.
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
-    :param [on_property_dropped]: handler called on every ignored property.
+    :param options: optional processing options; see Options below.
+    :param on_property_dropped: handler called on every ignored property.
 
     :return: the expanded JSON-LD output.
     """
@@ -205,51 +206,26 @@ def expand(input_, options=None, on_property_dropped: OnPropertyDropped = noop):
     )
 
 
-def flatten(input_, ctx=None, options=None):
+def flatten(input_, ctx: Context | None = None, options: FlattenOptions | None = None):
     """
     Performs JSON-LD flattening.
 
     :param input_: the JSON-LD input to flatten.
     :param ctx: the JSON-LD context to compact with (default: None).
-    :param [options]: the options to use.
-      [base] the base IRI to use.
-      [expandContext] a context to expand with.
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: True).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        (default: 'json-ld-1.1').
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
+    :param options: optional processing options; see Options below.
 
     :return: the flattened JSON-LD output.
     """
     return JsonLdProcessor().flatten(input_, ctx, options)
 
 
-def frame(input_, frame, options=None):
+def frame(input_, frame, options: FrameOptions | None = None):
     """
     Performs JSON-LD framing.
 
     :param input_: the JSON-LD input to frame.
     :param frame: the JSON-LD frame to use.
-    :param [options]: the options to use.
-      [base] the base IRI to use.
-      [expandContext] a context to expand with.
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: False).
-      [embed] default @embed flag: '@last', '@always', '@never', '@link'
-        (default: '@last').
-      [explicit] default @explicit flag (default: False).
-      [omitDefault] default @omitDefault flag (default: False).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        defaults to 'json-ld-1.1'.
-      [pruneBlankNodeIdentifiers] remove unnecessary blank node identifiers
-        (default: True)
-      [requireAll] default @requireAll flag (default: False).
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
+    :param options: optional processing options; see Options below.
 
     :return: the framed JSON-LD output.
     """
@@ -264,7 +240,7 @@ def link(input_, ctx, options=None):
 
     :param input_: the JSON-LD document to link.
     :param ctx: the JSON-LD context to apply or None.
-    :param [options]: the options to use.
+    :param options: the options to use.
       [base] the base IRI to use.
       [expandContext] a context to expand with.
       [extractAllScripts] True to extract all JSON-LD script elements
@@ -286,73 +262,39 @@ def link(input_, ctx, options=None):
     return frame(input_, frame_, options)
 
 
-def normalize(input_, options=None):
+def normalize(input_, options: NormalizeOptions | None = None):
     """
     Performs RDF dataset normalization on the given input. The input is
     JSON-LD unless the 'inputFormat' option is used. The output is an RDF
-    dataset unless the 'format' option is used'.
+    dataset unless the 'format' option is used.
 
     :param input_: the JSON-LD input to normalize.
-    :param [options]: the options to use.
-      [algorithm] the algorithm to use: `URDNA2015` or `URGNA2012`
-        (default: `URGNA2012`).
-      [base] the base IRI to use.
-      [inputFormat] the format if input is not JSON-LD:
-        'application/n-quads' for N-Quads.
-      [format] the format if output is a string:
-        'application/n-quads' for N-Quads.
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: False).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        defaults to 'json-ld-1.1'.
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
+    :param options: optional processing options; see Options below.
 
     :return: the normalized output.
     """
     return JsonLdProcessor().normalize(input_, options)
 
 
-def from_rdf(input_, options=None):
+def from_rdf(input_, options: FromRdfOptions | None = None):
     """
     Converts an RDF dataset to JSON-LD.
 
     :param input_: a serialized string of RDF in a format specified
       by the format option or an RDF dataset to convert.
-    :param [options]: the options to use:
-      [format] the format if input is a string:
-        'application/n-quads' for N-Quads (default: 'application/n-quads').
-      [useRdfType] True to use rdf:type, False to use @type (default: False).
-      [useNativeTypes] True to convert XSD types into native types
-        (boolean, integer, double), False not to (default: True).
-      [rdfDirection] Either 'i18n-datatype' or 'compound-literal'
-        is supported. (default: None)
+    :param options: optional processing options; see Options below.
 
     :return: the JSON-LD output.
     """
     return JsonLdProcessor().from_rdf(input_, options)
 
 
-def to_rdf(input_, options=None):
+def to_rdf(input_, options: ToRdfOptions | None = None):
     """
     Outputs the RDF dataset found in the given JSON-LD object.
 
     :param input_: the JSON-LD input.
-    :param [options]: the options to use.
-      [base] the base IRI to use.
-      [format] the format to use to output a string:
-        'application/n-quads' for N-Quads.
-      [produceGeneralizedRdf] true to output generalized RDF, false
-        to produce only standard RDF (default: false).
-      [extractAllScripts] True to extract all JSON-LD script elements
-        from HTML, False to extract just the first
-        (default: True).
-      [processingMode] Either 'json-ld-1.0' or 'json-ld-1.1',
-        defaults to 'json-ld-1.1'.
-      [documentLoader(url, options)] the document loader
-        (default: _default_document_loader).
-      [rdfDirection] Only 'i18n-datatype' supported.
+    :param options: optional processing options; see Options below.
 
     :return: the resulting RDF dataset (or a serialization of it).
     """
@@ -1232,7 +1174,7 @@ class JsonLdProcessor:
         :param subject: the subject to add the value to.
         :param property: the property that relates the value to the subject.
         :param value: the value to add.
-        :param [options]: the options to use:
+        :param options: the options to use:
           [propertyIsArray] True if the property is always
             an array, False if not (default: False).
           [valueIsArray] True if the value to be added should be preserved as
@@ -1312,7 +1254,7 @@ class JsonLdProcessor:
         :param subject: the subject.
         :param property: the property that relates the value to the subject.
         :param value: the value to remove.
-        :param [options]: the options to use:
+        :param options: the options to use:
           [propertyIsArray]: True if the property is always an array,
             False if not (default: False).
         """

--- a/lib/pyld/options.py
+++ b/lib/pyld/options.py
@@ -1,0 +1,193 @@
+"""
+TypedDict types for JSON-LD API options.
+
+.. module:: options
+  :synopsis: Option dict types for JSON-LD API functions
+"""
+
+from collections.abc import Callable
+from typing import Any, Literal, TypedDict
+
+from .documentloader.base import DocumentLoader, RemoteDocument
+
+ContextObject = dict[str, Any]
+Context = str | ContextObject | list[str | ContextObject]
+"""JSON-LD context value: remote URL, inline object, or ordered stack."""
+
+DocumentLoaderCallable = Callable[[str, dict[str, Any]], RemoteDocument]
+
+
+class DocumentLoaderOptions(TypedDict, total=False):
+    """Options shared by APIs that load remote contexts."""
+
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+
+class ProcessingOptions(DocumentLoaderOptions, total=False):
+    """Options shared by JSON-LD processing APIs."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `False`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+
+class ExpandContextOptions(ProcessingOptions, total=False):
+    """Processing options that accept an expand context."""
+
+    expandContext: Context
+    """A context to expand with."""
+
+
+class CompactOptions(ExpandContextOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `False`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    expandContext: Context
+    """A context to expand with."""
+
+    compactArrays: bool
+    """`True` to compact arrays to single values when appropriate, `False` not to (default: `True`)."""
+
+    graph: bool
+    """`True` to always output a top-level graph (default: `False`)."""
+
+
+class ExpandOptions(ExpandContextOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `False`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    expandContext: Context
+    """A context to expand with."""
+
+
+class FlattenOptions(ExpandContextOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `True`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    expandContext: Context
+    """A context to expand with."""
+
+
+class FrameOptions(ExpandContextOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `False`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    expandContext: Context
+    """A context to expand with."""
+
+    embed: Literal['@last', '@always', '@never', '@link']
+    """Default `@embed` flag (default: `@last`)."""
+
+    explicit: bool
+    """Default `@explicit` flag (default: `False`)."""
+
+    omitDefault: bool
+    """Default `@omitDefault` flag (default: `False`)."""
+
+    pruneBlankNodeIdentifiers: bool
+    """Remove unnecessary blank node identifiers (default: `True`)."""
+
+    requireAll: bool
+    """Default `@requireAll` flag (default: `False`)."""
+
+
+class NormalizeOptions(ProcessingOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `False`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    algorithm: Literal['URDNA2015', 'URGNA2012']
+    """The algorithm to use (default: `URGNA2012`)."""
+
+    inputFormat: Literal['application/n-quads']
+    """The format if input is not JSON-LD: `application/n-quads` for N-Quads."""
+
+    format: Literal['application/n-quads']
+    """The format if output is a string: `application/n-quads` for N-Quads."""
+
+
+class ToRdfOptions(ProcessingOptions, total=False):
+    documentLoader: DocumentLoader | DocumentLoaderCallable
+    """The document loader (default: the global default document loader)."""
+
+    base: str
+    """The base IRI to use."""
+
+    extractAllScripts: bool
+    """`True` to extract all JSON-LD script elements from HTML, `False` to extract just the first (default: `True`)."""
+
+    processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
+    """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
+
+    format: Literal['application/n-quads']
+    """The format to use to output a string: `application/n-quads` for N-Quads."""
+
+    produceGeneralizedRdf: bool
+    """`True` to output generalized RDF, `False` to produce only standard RDF (default: `False`)."""
+
+    rdfDirection: Literal['i18n-datatype']
+    """Only `i18n-datatype` supported."""
+
+
+class FromRdfOptions(TypedDict, total=False):
+    format: Literal['application/n-quads']
+    """The format if input is a string: `application/n-quads` for N-Quads (default: `application/n-quads`)."""
+
+    useRdfType: bool
+    """`True` to use `rdf:type`, `False` to use `@type` (default: `False`)."""
+
+    useNativeTypes: bool
+    """`True` to convert XSD types into native types (boolean, integer, double), `False` not to (default: `True`)."""
+
+    rdfDirection: Literal['i18n-datatype', 'compound-literal']
+    """Either `i18n-datatype` or `compound-literal` is supported (default: `None`)."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,4 +43,15 @@ plugins:
       collapse_single_pages: true
   - macros:
       module_name: docs_macros
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: sphinx
+            show_root_heading: false
+            show_root_full_path: false
+            show_source: false
+            separate_signature: true
+            show_signature_annotations: true
+            heading_level: 2
   - search


### PR DESCRIPTION
## Summary

- Add `lib/pyld/options.py` with `Context`, shared base TypedDicts, and per-function `*Options` types for the seven JSON-LD APIs
- Annotate `jsonld` module functions and export the new types
- Add mkdocstrings-powered reference pages for each API with Options sections
- Link front-page quick examples to reference pages; update reference index, AGENTS.md, and CHANGELOG

## Test plan

- [x] `make lint`
- [x] `make docs-build --strict`
- [ ] CI