### PR TITLE
Throw error on inline contexts redefining @context

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -2856,7 +2856,19 @@ class JsonLdProcessor:
         # Local contexts on the nested node apply before looking for @type,
         # just like they do for an ordinary node object.
         if '@context' in element:
-            active_ctx = self._process_context(active_ctx, element['@context'], options)
+            local_ctx = element['@context']
+            if (
+                _is_object(local_ctx)
+                and len(local_ctx) == 1
+                and '@context' in local_ctx
+            ):
+                raise JsonLdError(
+                    'Invalid JSON-LD syntax; keywords cannot be overridden.',
+                    'jsonld.SyntaxError',
+                    {'context': local_ctx, 'term': '@context'},
+                    code='keyword redefinition',
+                )
+            active_ctx = self._process_context(active_ctx, local_ctx, options)
 
         # Set the type-scoped context to the context on input, for use later
         type_scoped_ctx = active_ctx

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -950,10 +950,7 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [
-                # uncategorized
-                '.*expand-manifest#ter56$',
-            ],
+            'idRegex': [],
         },
         'fn': 'expand',
         'params': [read_test_url('input'), create_test_options()],
@@ -1023,7 +1020,6 @@ TEST_TYPES = {
                 # well formed
                 '.*toRdf-manifest#twf05$',
                 # uncategorized
-                '.*toRdf-manifest#ter56$',
                 '.*toRdf-manifest#tli12$',
                 '.*toRdf-manifest#tli14$',
             ]

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -119,6 +119,25 @@ class TestExpand:
             {"http://example.com/prop": [{"@value": "value"}]}
         ]
 
+    def test_context_keyword_redefinition_fails(self):
+        """
+        A local context must not define @context as a term.
+        """
+        input = {
+            "@context": {
+                "@context": {
+                    "p": "ex:p",
+                },
+            },
+            "@id": "ex:1",
+            "p": "value",
+        }
+
+        with pytest.raises(jsonld.JsonLdError) as exc:
+            jsonld.expand(input)
+
+        assert exc.value.code == 'keyword redefinition'
+
     def test_dropped_keys_complex(self):
         """
         Complex example with keys not in the context should correctly store


### PR DESCRIPTION
Fixes tests 

- https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ter56
- https://w3c.github.io/json-ld-api/tests/expand-manifest.html#ter56

> Verifies that an exception is raised when attempting to redefine @context.

This PR extents the expansion guard for inline contexts that try to redefine @context and adds a regression test