### PR TITLE
Treat TypeError also as non-numeric

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -6402,7 +6402,7 @@ def _is_numeric(v):
     try:
         float(v)
         return True
-    except ValueError:
+    except (TypeError, ValueError):
         return False
 
 

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -518,6 +518,22 @@ class TestExpand:
         expanded = jsonld.expand(input)
         assert expanded == expected
 
+    def test_expand_stringifies_datetime_date_values(self):
+        """
+        Non-JSON scalar objects such as datetime.date should get stringified.
+        """
+        from datetime import date
+
+        expanded = jsonld.expand({
+            '@context': {'@vocab': 'https://schema.org/'},
+            '@id': 'https://example.blog/post',
+            'publicationDate': date(2021, 1, 11),
+        })
+
+        assert expanded == [{
+            '@id': 'https://example.blog/post',
+            'https://schema.org/publicationDate': [{'@value': '2021-01-11'}],
+        }]
 
 class TestFrame:
     # Issue 11 - PR: https://github.com/digitalbazaar/pyld/issues/149


### PR DESCRIPTION
Fixes #146. `_is_numeric()` now treats `TypeError` like `ValueError`, so non-JSON scalar objects such as `datetime.date` get stringified instead of crashing.