### PR TITLE
Fix integer serialization with fractional part

### DIFF
--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3960,7 +3960,7 @@ class JsonLdProcessor:
                     object['datatype'] = XSD_DOUBLE
                     return object
             elif _is_integer(value):
-                object['value'] = str(value)
+                object['value'] = str(int(value))
                 object['datatype'] = datatype or XSD_INTEGER
             elif rdf_direction == 'compound-literal' and '@direction' in item:
                 object['type'] = 'blank node'
@@ -6372,7 +6372,7 @@ def _is_integer(v):
 
     :return: True if the value is an Integer, False if not.
     """
-    return isinstance(v, Integral)
+    return isinstance(v, Integral) or (isinstance(v, Real) and float(v).is_integer())
 
 
 def _is_double(v):
@@ -6383,7 +6383,7 @@ def _is_double(v):
 
     :return: True if the value is a Double, False if not.
     """
-    return not isinstance(v, Integral) and isinstance(v, Real)
+    return not isinstance(v, Integral) and isinstance(v, Real) and not float(v).is_integer()
 
 
 def _canonicalize_double(value: float) -> str:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1015,8 +1015,6 @@ TEST_TYPES = {
                 '.*toRdf-manifest#te112$',
                 # number fixes
                 '.*toRdf-manifest#trt01$',
-                # type:none
-                '.*toRdf-manifest#ttn02$',
                 # well formed
                 '.*toRdf-manifest#twf05$',
                 # uncategorized

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1041,6 +1041,17 @@ _:b0 <http://purl.org/dc/terms/title> "Chapter 1: Jonathan Harker's Journal" .
         nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
         assert nquads == expected
 
+    # Issue 177
+    def test_fractional(self):
+        """
+        Number with 0 fractional part should parse to an xsd:integer
+        """
+        input = { "ex:value": 42.0 }
+
+        expected = '[] <ex:value> "42"^^xsd:integer.'
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+        assert nquads == expected
 
 class TestFromRDF:
     def test_compound_literal_direction_without_language(self):

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1048,7 +1048,7 @@ _:b0 <http://purl.org/dc/terms/title> "Chapter 1: Jonathan Harker's Journal" .
         """
         input = { "ex:value": 42.0 }
 
-        expected = '[] <ex:value> "42"^^xsd:integer.'
+        expected = '_:b0 <ex:value> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
 
         nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
         assert nquads == expected


### PR DESCRIPTION
Fixes #177 . This also fixes [toRdf-manifest#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02)