### PR TITLE
Add blank nodes to prefix check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - When using native types, values of `xsd:boolean` and `xsd:integer` are now properly converted. Fixes [fromRdf#t0027](https://w3c.github.io/json-ld-api/tests/fromRdf-manifest.html#t0027).
 - Numbers with 0 as fractional part now parse to an `xsd:integer` instead of `xsd:double`. Fixes [toRdf#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02).
 - Zeros are now truncated for numeric values with negative exponent.
+- Blank node prefixes are now also used in IRI expansion.
 
 ## 3.1.0 - 2026-06-19
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -5742,7 +5742,10 @@ class JsonLdProcessor:
                 mapping['_prefix'] = (
                     _simple_term
                     and not mapping['_term_has_colon']
-                    and bool(re.match(r'.*[:/\?#\[\]@]$', id_))
+                    and (
+                        id_.startswith('_:')
+                        or bool(re.match(r'.*[:/\?#\[\]@]$', id_))
+                    )
                 )
         if '@id' not in mapping:
             # see if the term has a prefix

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -535,6 +535,20 @@ class TestExpand:
             'https://schema.org/publicationDate': [{'@value': '2021-01-11'}],
         }]
 
+    # Issue 167
+    def test_blank_node_prefixes(self):
+        """
+        Blank nodes as prefix should be used in IRI expansion. 
+        """
+        input = {"@context": {"t": "_:b"}, "@type": "t:x"}
+
+        expected = [{"@type": ["_:bx"]}]
+
+        expanded = jsonld.expand(input)
+
+        assert expanded == expected
+
+
 class TestFrame:
     # Issue 11 - PR: https://github.com/digitalbazaar/pyld/issues/149
     """

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -538,7 +538,7 @@ class TestExpand:
     # Issue 167
     def test_blank_node_prefixes(self):
         """
-        Blank nodes as prefix should be used in IRI expansion. 
+        Blank nodes as prefix should be used in IRI expansion.
         """
         input = {"@context": {"t": "_:b"}, "@type": "t:x"}
 


### PR DESCRIPTION
Fixes #167 by also checking for blank nodes when resolving prefixes for IRI expansion.