### PR TITLE
Represent large numbers with no fractions as double for values >= 1e21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Numbers with 0 as fractional part now parse to an `xsd:integer` instead of `xsd:double`. Fixes [toRdf#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02).
 - Zeros are now truncated for numeric values with negative exponent.
 - Blank node prefixes are now also used in IRI expansion.
+- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double
 
 ## 3.1.0 - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Numbers with 0 as fractional part now parse to an `xsd:integer` instead of `xsd:double`. Fixes [toRdf#ttn02](https://w3c.github.io/json-ld-api/tests/toRdf-manifest.html#ttn02).
 - Zeros are now truncated for numeric values with negative exponent.
 - Blank node prefixes are now also used in IRI expansion.
-- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double
+- Numbers with no fractions but that are >= 1e21 are now represented as xsd:double in json-ld-1.1 processing mode.
 
 ## 3.1.0 - 2026-06-19
 

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3959,6 +3959,10 @@ class JsonLdProcessor:
                     object['value'] = _canonicalize_double(float_value)
                     object['datatype'] = XSD_DOUBLE
                     return object
+            # Numbers without fractions but larger or equal to 1e21 should be double
+            elif _is_integer(value) and value >= 1e21:
+                object['value'] = _canonicalize_double(value)
+                object['datatype'] = XSD_DOUBLE
             elif _is_integer(value):
                 object['value'] = str(int(value))
                 object['datatype'] = datatype or XSD_INTEGER

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3960,9 +3960,9 @@ class JsonLdProcessor:
                     object['datatype'] = XSD_DOUBLE
                     return object
             # Numbers without fractions but larger or equal to 1e21 should be double
-            elif _is_integer(value) and value >= 1e21:
+            elif _is_integer(value) and abs(value) >= 1e21:
                 object['value'] = _canonicalize_double(value)
-                object['datatype'] = XSD_DOUBLE
+                object['datatype'] = datatype or XSD_DOUBLE
             elif _is_integer(value):
                 object['value'] = str(int(value))
                 object['datatype'] = datatype or XSD_INTEGER

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3861,9 +3861,7 @@ class JsonLdProcessor:
                     predicate['value'] = property
 
                     # convert list, value or node object to triple
-                    object = self._object_to_rdf(
-                        item, issuer, triples, options.get('rdfDirection')
-                    )
+                    object = self._object_to_rdf(item, issuer, triples, options)
                     # skip None objects (they are relative IRIs)
                     if object is not None:
                         triples.append(
@@ -3875,7 +3873,7 @@ class JsonLdProcessor:
                         )
         return triples
 
-    def _list_to_rdf(self, list_, issuer, triples, rdf_direction):
+    def _list_to_rdf(self, list_, issuer, triples, options):
         """
         Converts a @list value into a linked list of blank node RDF triples
         (and RDF collection).
@@ -3883,7 +3881,7 @@ class JsonLdProcessor:
         :param list_: the @list value.
         :param issuer: the IdentifierIssuer for issuing blank node identifiers.
         :param triples: the array of triples to append to.
-        :param rdf_direction: for creating datatyped literals.
+        :param options: the RDF serialization options.
 
         :return: the head of the list
         """
@@ -3897,7 +3895,7 @@ class JsonLdProcessor:
         subject = result
 
         for item in list_:
-            object = self._object_to_rdf(item, issuer, triples, rdf_direction)
+            object = self._object_to_rdf(item, issuer, triples, options)
             next = {'type': 'blank node', 'value': issuer.get_id()}
             triples.append({'subject': subject, 'predicate': first, 'object': object})
             triples.append({'subject': subject, 'predicate': rest, 'object': next})
@@ -3906,13 +3904,13 @@ class JsonLdProcessor:
 
         # tail of list
         if last:
-            object = self._object_to_rdf(last, issuer, triples, rdf_direction)
+            object = self._object_to_rdf(last, issuer, triples, options)
             triples.append({'subject': subject, 'predicate': first, 'object': object})
             triples.append({'subject': subject, 'predicate': rest, 'object': nil})
 
         return result
 
-    def _object_to_rdf(self, item, issuer, triples, rdf_direction):
+    def _object_to_rdf(self, item, issuer, triples, options):
         """
         Converts a JSON-LD value object to an RDF literal or a JSON-LD string
         or node object to an RDF resource.
@@ -3920,7 +3918,7 @@ class JsonLdProcessor:
         :param item: the JSON-LD value or node object.
         :param issuer: the IdentifierIssuer for issuing blank node identifiers.
         :param triples: the array of triples to append list entries to.
-        :param rdf_direction: for creating directional literals.
+        :param options: the RDF serialization options.
 
         :return: the RDF literal or RDF resource.
         """
@@ -3930,6 +3928,7 @@ class JsonLdProcessor:
             object['type'] = 'literal'
             value = item['@value']
             datatype = item.get('@type')
+            rdf_direction = options.get('rdfDirection')
 
             # convert to XSD datatypes as appropriate
             if datatype == '@json':
@@ -3959,8 +3958,11 @@ class JsonLdProcessor:
                     object['value'] = _canonicalize_double(float_value)
                     object['datatype'] = XSD_DOUBLE
                     return object
-            # Numbers without fractions but larger or equal to 1e21 should be double
-            elif _is_integer(value) and abs(value) >= 1e21:
+            elif (
+                options['processingMode'] == 'json-ld-1.1'
+                and _is_integer(value)
+                and abs(value) >= 1e21
+            ):
                 object['value'] = _canonicalize_double(value)
                 object['datatype'] = datatype or XSD_DOUBLE
             elif _is_integer(value):
@@ -4019,7 +4021,7 @@ class JsonLdProcessor:
                 object['datatype'] = datatype or XSD_STRING
         # convert list object to RDF
         elif _is_list(item):
-            list_ = self._list_to_rdf(item['@list'], issuer, triples, rdf_direction)
+            list_ = self._list_to_rdf(item['@list'], issuer, triples, options)
             object['value'] = list_['value']
             object['type'] = list_['type']
         # convert string/node object to RDF

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1013,8 +1013,6 @@ TEST_TYPES = {
                 # rel vocab
                 '.*toRdf-manifest#te111$',
                 '.*toRdf-manifest#te112$',
-                # number fixes
-                '.*toRdf-manifest#trt01$',
                 # well formed
                 '.*toRdf-manifest#twf05$',
                 # uncategorized

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -947,6 +947,35 @@ class TestToRdf:
         result = jsonld.to_rdf(input)
         assert result == expected
 
+    def test_large_integer_to_rdf_double_conversion_processing_mode(self):
+        """
+        In json-ld-1.1 processing mode, large integers should be emitted as xsd:double,
+        while in json-ld-1.0 processing mode, they should be kept as xsd:integer.
+        """
+        input = {
+            '@id': 'http://example.com/s',
+            'http://example.com/p': 1000000000000000000000,
+        }
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+        assert nquads == (
+            '<http://example.com/s> <http://example.com/p> '
+            '"1.0E21"^^<http://www.w3.org/2001/XMLSchema#double> .\n'
+        )
+
+        nquads = jsonld.to_rdf(
+            input,
+            options={
+                'format': 'application/n-quads',
+                'processingMode': 'json-ld-1.0',
+            },
+        )
+        assert nquads == (
+            '<http://example.com/s> <http://example.com/p> '
+            '"1000000000000000000000"'
+            '^^<http://www.w3.org/2001/XMLSchema#integer> .\n'
+        )
+
     def test_compound_literal_direction_without_language(self):
         """
         Values with @direction should become compound literals during to_rdf


### PR DESCRIPTION
Fixes [toRdf-manifest#trt01](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#trt01)