### PR TITLE
Skip invalid URIs in RDF serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 - Preserved RDF literal lexical forms when converting through RDFLib, including canonical double output, large numeric values, and compound literal handling.
 - Fixed `iri_resolver.unresolve()` query/fragment reconstruction while cleaning up the resolver docstring.
 
+### Fixed
+
+- Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
+
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.
   - `jsonld.to_rdf()` now returns an `rdflib.Dataset` by default when no output `format` is requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@
 
 - Preserved RDF literal lexical forms when converting through RDFLib, including canonical double output, large numeric values, and compound literal handling.
 - Fixed `iri_resolver.unresolve()` query/fragment reconstruction while cleaning up the resolver docstring.
-
-### Fixed
-
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
 
 ### Changed

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -35,7 +35,7 @@ from rdflib import RDF, XSD, BNode, Dataset, Literal, Node, URIRef
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.parser import StringInputSource
 from rdflib.plugins.serializers.nquads import _nq_row
-from rdflib.term import Identifier
+from rdflib.term import Identifier, _is_valid_uri
 
 from c14n.Canonicalize import canonicalize
 from pyld.__about__ import __copyright__, __license__, __version__
@@ -1035,7 +1035,7 @@ class JsonLdProcessor:
         dataset = Dataset()
         for graph_name, graph in sorted(node_map.items()):
             # skip relative IRIs
-            if graph_name == '@default' or _is_absolute_iri(graph_name):
+            if graph_name == '@default' or _is_valid_absolute_iri(graph_name):
                 g = self._rdflib_term_from_id(graph_name) if graph_name != '@default' else dataset.default_graph
                 for t in self._graph_to_rdf(graph, issuer, options):
                     s, p, o = t
@@ -3867,8 +3867,8 @@ class JsonLdProcessor:
 
                 for item in items:
                     # skip relative IRI subjects and predicates
-                    if not _is_absolute_iri(id_) or (
-                        property != '@type' and not _is_absolute_iri(property)
+                    if not _is_valid_absolute_iri(id_) or (
+                        property != '@type' and not _is_valid_absolute_iri(property)
                     ):
                         continue
 
@@ -3906,13 +3906,14 @@ class JsonLdProcessor:
 
         last = list_.pop() if list_ else None
         # result is the head of the list
-        result = BNode(issuer.get_id()) if last else RDF.nil
+        result = self._rdflib_term_from_id(issuer.get_id()) if last else RDF.nil
         subject = result
 
         for item in list_:
             object = self._object_to_rdf(item, issuer, triples, options)
-            next = BNode(issuer.get_id())
-            triples.append((subject, RDF.first, object))
+            next = self._rdflib_term_from_id(issuer.get_id())
+            if object is not None:
+                triples.append((subject, RDF.first, object))
             triples.append((subject, RDF.rest, next))
 
             subject = next
@@ -3920,7 +3921,8 @@ class JsonLdProcessor:
         # tail of list
         if last:
             object = self._object_to_rdf(last, issuer, triples, options)
-            triples.append((subject, RDF.first, object))
+            if object is not None:
+                triples.append((subject, RDF.first, object))
             triples.append((subject, RDF.rest, RDF.nil))
 
         return result
@@ -4066,7 +4068,7 @@ class JsonLdProcessor:
             id_ = item['@id'] if _is_object(item) else item
 
         # skip relative IRIs
-        if not id_.startswith('_:') and not _is_absolute_iri(id_):
+        if not id_.startswith('_:') and not _is_valid_absolute_iri(id_):
             return None
 
         return self._rdflib_term_from_id(id_)
@@ -6562,6 +6564,18 @@ def _is_absolute_iri(v):
     :return: True if the value is an absolute IRI, False if not.
     """
     return _is_string(v) and re.match(r'^([A-Za-z][A-Za-z0-9+-.]*|_):[^\s]*$', v)
+
+
+def _is_valid_absolute_iri(v):
+    """
+    Returns True if the given value is an absolute IRI that RDFLib can
+    serialize, False if not.
+
+    :param v: the value to check.
+
+    :return: True if the value is a valid absolute IRI, False if not.
+    """
+    return _is_absolute_iri(v) and _is_valid_uri(v)
 
 
 def _is_relative_iri(v):

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1022,9 +1022,6 @@ TEST_TYPES = {
                 '.*toRdf-manifest#te112$',
                 # well formed
                 '.*toRdf-manifest#twf05$',
-                # uncategorized
-                '.*toRdf-manifest#tli12$',
-                '.*toRdf-manifest#tli14$',
             ]
         },
         'skip': {

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1167,6 +1167,32 @@ _:b0 <http://purl.org/dc/terms/title> "Chapter 1: Jonathan Harker's Journal"^^<h
         nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
         assert nquads == expected
 
+    def test_list_skips_invalid_iri_items(self):
+        """
+        Conversion to RDF should skip invalid list item IRIs without dropping
+        the list node.
+        """
+        input = {
+            "@context": {
+                "@base": "http://invalid/<>/",
+                "list": {
+                    "@id": "foo:bar",
+                    "@container": "@list",
+                    "@type": "@id",
+                },
+            },
+            "list": ["test"],
+        }
+
+        expected = """_:b0 <foo:bar> _:b1  .
+_:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>  .
+
+"""
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+        assert sorted(nquads.splitlines()) == sorted(expected.splitlines())
+
+
 class TestFromRDF:
     def test_compound_literal_direction_without_language(self):
         """


### PR DESCRIPTION
Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) &  [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).

When invalid base values occur within lists, they are skipped when serializing to RDF.