### PR TITLE
Prevent repeating the headers argument when setting custom headers.

### DIFF
--- a/lib/pyld/documentloader/requests.py
+++ b/lib/pyld/documentloader/requests.py
@@ -28,6 +28,7 @@ class RequestsDocumentLoader(DocumentLoader):
             session = requests.Session()
         self.session = session
         self.secure = secure
+        self.headers = kwargs.pop('headers', None)
         self.kwargs = kwargs
 
     def __call__(self, url, options=None) -> RemoteDocument:
@@ -58,7 +59,7 @@ class RequestsDocumentLoader(DocumentLoader):
                     'the URL\'s scheme is not "https".',
                     'jsonld.InvalidUrl', {'url': url},
                     code='loading document failed')
-            headers = options.get('headers')
+            headers = options.get('headers', self.headers)
             if headers is None:
                 headers = {
                     'Accept': 'application/ld+json, application/json'

--- a/tests/test_document_loader.py
+++ b/tests/test_document_loader.py
@@ -88,6 +88,32 @@ def test_requests_document_loader_factory_returns_document_loader():
     assert callable(loader)
 
 
+def test_requests_document_loader_accepts_custom_headers():
+    """Requests factory accepts default headers without passing headers twice."""
+    class Response:
+        headers = {'content-type': 'application/ld+json'}
+        url = 'http://example.com/context'
+
+        def json(self):
+            return {'@context': {}}
+
+    class Session:
+        def __init__(self):
+            self.headers = None
+
+        def get(self, url, headers=None):
+            self.headers = headers
+            return Response()
+
+    session = Session()
+    headers = {'Accept': 'application/json'}
+
+    loader = jsonld.requests_document_loader(session=session, headers=headers)
+    loader('http://example.com/context')
+
+    assert session.headers == headers
+
+
 def test_aiohttp_document_loader_factory_returns_document_loader():
     """Aiohttp factory returns a class-based callable document loader."""
     pytest.importorskip("aiohttp")


### PR DESCRIPTION
Fixes #125. Changed lib/pyld/documentloader/requests.py so constructor-level headers are removed from `**kwargs` and stored separately, avoiding duplicate `headers=` when calling `session.get`. Per-call `options["headers"]` still takes precedence.