### PR TITLE
Skip triples when @language is invalid.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,7 @@
 - Preserved RDF literal lexical forms when converting through RDFLib, including canonical double output, large numeric values, and compound literal handling.
 - Fixed `iri_resolver.unresolve()` query/fragment reconstruction while cleaning up the resolver docstring.
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
-
-### Fixed
-
-- Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
+- Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - Fixed `iri_resolver.unresolve()` query/fragment reconstruction while cleaning up the resolver docstring.
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
 
+### Fixed
+
+- Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
+
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.
   - `jsonld.to_rdf()` now returns an `rdflib.Dataset` by default when no output `format` is requested.

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -3964,6 +3964,9 @@ class JsonLdProcessor:
             datatype = item.get('@type')
             rdf_direction = options.get('rdfDirection')
 
+            if '@language' in item and not re.match(REGEX_BCP47, item['@language']):
+                return None
+
             # convert to XSD datatypes as appropriate
             if datatype == '@json':
                 return Literal(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1020,8 +1020,6 @@ TEST_TYPES = {
                 # rel vocab
                 '.*toRdf-manifest#te111$',
                 '.*toRdf-manifest#te112$',
-                # well formed
-                '.*toRdf-manifest#twf05$',
             ]
         },
         'skip': {

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1087,6 +1087,21 @@ _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> "en-US"^^<http://www.w3.
 
         assert sorted(nquads.splitlines()) == sorted(expected.splitlines())
 
+    def test_invalid_language_tag_is_skipped(self):
+        """
+        Conversion to RDF should skip values with invalid language tags.
+        """
+        input = {
+            '@id': 'http://example.com/foo',
+            'http://example.com/bar': {
+                '@value': 'bar',
+                '@language': 'a b',
+            },
+        }
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+        assert nquads == '\n'
+
     # Issue 204
     def test_conflicting_property_names(self):
         """


### PR DESCRIPTION
Literals with invalid @language no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).