### PR TITLE
Make _is_valid_absolute_iri also count hash chars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed `iri_resolver.unresolve()` query/fragment reconstruction while cleaning up the resolver docstring.
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
 - Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
+- IRI validation now detects multiple # fragments so these IRI's are skipped during toRDF. Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
 - IRI validation now detects multiple # fragments so these IRI's are skipped during toRDF. Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).
 - In `_create_node_map()`, ignored `@id: None` subjects are now dropped before they enter the node map to prevent `_graph_to_rdf()` from crashing when sorting mixed `None` and string keys. Fixes [toRdf#te122](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122).
+- Use a helper for generalized N-Quads normalization in the test runner, since rdflib cannot parse blank-node predicates. Fixes [toRdf#te075](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
 - Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
 - IRI validation now detects multiple # fragments so these IRI's are skipped during toRDF. Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).
+- In `_create_node_map()`, ignored `@id: None` subjects are now dropped before they enter the node map to prevent `_graph_to_rdf()` from crashing when sorting mixed `None` and string keys. Fixes [toRdf#te122](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -6578,7 +6578,8 @@ def _is_valid_absolute_iri(v):
 
     :return: True if the value is a valid absolute IRI, False if not.
     """
-    return _is_absolute_iri(v) and _is_valid_uri(v)
+    # TODO: _is_valid_uri is flawed, so maybe replace it with something better
+    return _is_absolute_iri(v) and v.count('#') <= 1 and _is_valid_uri(v)
 
 
 def _is_relative_iri(v):

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -4241,6 +4241,10 @@ class JsonLdProcessor:
         id_ = input_.get('@id')
         if _is_bnode(input_):
             id_ = issuer.get_id(id_)
+        # drop explicitly ignored @id: None subjects before they enter the node map,
+        # while leaving normal blank nodes without @id alone.
+        elif id_ is None and '@id' in input_:
+            return
 
         # create new subject or merge into existing one
         node = graph_map.setdefault(active_graph, {}).setdefault(id_, {'@id': id_})

--- a/lib/pyld/options.py
+++ b/lib/pyld/options.py
@@ -146,8 +146,8 @@ class NormalizeOptions(ProcessingOptions, total=False):
     processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
     """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
 
-    algorithm: Literal['URDNA2015', 'URGNA2012']
-    """The algorithm to use (default: `URGNA2012`)."""
+    algorithm: Literal['URDNA2015', 'URGNA2012', 'RDFC10']
+    """The algorithm to use (default: `RDFC10`)."""
 
     inputFormat: Literal['application/n-quads']
     """The format if input is not JSON-LD: `application/n-quads` for N-Quads."""

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -858,7 +858,6 @@ class EarlTestResult(TextTestResult):
     def writeReport(self, filename):
         self.report.write(filename)
 
-
 class EarlReport:
     """
     Generates an EARL report.
@@ -901,7 +900,10 @@ class EarlReport:
             'dc:title': 'PyLD',
             'doap:homepage': 'https://github.com/digitalbazaar/pyld',
             'doap:license': 'https://github.com/digitalbazaar/pyld/blob/master/LICENSE',
-            'doap:description': 'A JSON-LD processor for Python',
+            'doap:description': {
+                '@value': 'A JSON-LD processor for Python',
+                '@language': 'en',
+            },
             'doap:programming-language': 'Python',
             'dc:creator': 'https://github.com/dlongley',
             'doap:developer': {

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1017,9 +1017,6 @@ TEST_TYPES = {
                 # blank node property
                 '.*toRdf-manifest#te075$',
                 '.*toRdf-manifest#te122$',
-                # rel vocab
-                '.*toRdf-manifest#te111$',
-                '.*toRdf-manifest#te112$',
             ]
         },
         'skip': {

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -455,23 +455,29 @@ class Test(unittest.TestCase):
             if self.is_syntax and not self.pending:
                 self.assertTrue(True)
             elif self.test_type == 'jld:ToRDFTest':
-                # Test normalized results
-                result = jsonld.normalize(
-                    result,
-                    {
-                        'algorithm': 'URGNA2012',
-                        'inputFormat': 'application/n-quads',
-                        'format': 'application/n-quads',
-                    },
-                )
-                expect = jsonld.normalize(
-                    expect,
-                    {
-                        'algorithm': 'URGNA2012',
-                        'inputFormat': 'application/n-quads',
-                        'format': 'application/n-quads',
-                    },
-                )
+                # avoid normalization when produceGeneralizedRdf is enabled,
+                # since the rdflib parser cannot parse blank-node predicates.
+                if data.get('option', {}).get('produceGeneralizedRdf'):
+                    result = _normalize_generalized_nquads_text(result)
+                    expect = _normalize_generalized_nquads_text(expect)
+                else:
+                    # Test normalized results
+                    result = jsonld.normalize(
+                        result,
+                        {
+                            'algorithm': 'RDFC10',
+                            'inputFormat': 'application/n-quads',
+                            'format': 'application/n-quads',
+                        },
+                    )
+                    expect = jsonld.normalize(
+                        expect,
+                        {
+                            'algorithm': 'RDFC10',
+                            'inputFormat': 'application/n-quads',
+                            'format': 'application/n-quads',
+                        },
+                    )
                 if _running_under_pytest():
                     assert result == expect
                 else:
@@ -533,6 +539,26 @@ def assert_results_equal(result, expect, json_output=False):
 
 def _running_under_pytest():
     return 'pytest' in sys.modules
+
+
+def _normalize_generalized_nquads_text(nquads):
+    """Normalize generalized N-Quads text for test-suite comparisons."""
+    # Remove string datatype
+    nquads = nquads.replace(
+        '^^<http://www.w3.org/2001/XMLSchema#string>  .',
+        '.',
+    )
+
+    # Re-label blank nodes
+    bnodes = {}
+
+    # Generalized N-Quads expected results only need deterministic comparison,
+    # not preservation of input blank node labels.
+    nquads = re.sub(r'_:([A-Za-z][A-Za-z0-9]*)', lambda m: bnodes.setdefault(m[0], f'_:b{len(bnodes)}'), nquads)
+    lines = (re.sub(r'\s*\.$', '.', line.strip()) for line in nquads.splitlines())
+
+    # Sort nquads
+    return '\n'.join(sorted(line for line in lines if line))
 
 
 # Compare values with order-insensitive array tests
@@ -925,7 +951,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'compact',
         'params': [
@@ -957,7 +982,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'expand',
         'params': [read_test_url('input'), create_test_options()],
@@ -968,7 +992,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'flatten',
         'params': [
@@ -983,7 +1006,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'frame',
         'params': [
@@ -995,7 +1017,6 @@ TEST_TYPES = {
     'jld:FromRDFTest': {
         'skip': {
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'from_rdf',
         'params': [
@@ -1012,17 +1033,11 @@ TEST_TYPES = {
         ],
     },
     'jld:ToRDFTest': {
-        'pending': {
-            'idRegex': [
-                # blank node property
-                '.*toRdf-manifest#te075$',
-            ]
-        },
+        'pending': {},
         'skip': {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'to_rdf',
         'params': [
@@ -1031,8 +1046,8 @@ TEST_TYPES = {
         ],
     },
     'rdfn:Urgna2012EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1046,8 +1061,8 @@ TEST_TYPES = {
         ],
     },
     'rdfn:Urdna2015EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1061,8 +1076,8 @@ TEST_TYPES = {
         ],
     },
     'rdfc:RDFC10EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1074,12 +1089,8 @@ TEST_TYPES = {
         ]
     },
     'rdfc:RDFC10MapTest': {
-        'pending': {
-            'idRegex': []
-        },
-        'skip': {
-            'idRegex': []
-        },
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1016,7 +1016,6 @@ TEST_TYPES = {
             'idRegex': [
                 # blank node property
                 '.*toRdf-manifest#te075$',
-                '.*toRdf-manifest#te122$',
             ]
         },
         'skip': {

--- a/tests/test_jsonld.py
+++ b/tests/test_jsonld.py
@@ -1000,6 +1000,33 @@ class TestToRdf:
             "^^<http://www.w3.org/2001/XMLSchema#double>  .\n\n"
         )
 
+    def test_to_rdf_skips_relative_vocab_property_that_expands_to_invalid_iri(self):
+        """
+        to_rdf should omit property IRIs that expand to invalid RDF IRIs.
+        """
+        input = {
+            "@context": [
+                {
+                    "@version": 1.1,
+                    "@base": "http://example.com/some/deep/directory/and/file/",
+                    "@vocab": "http://example.com/vocabulary/",
+                },
+                {"@vocab": "./rel2#"},
+            ],
+            "@id": "relativePropertyIris",
+            "link": "link",
+            "#fragment-works": "#fragment-works",
+        }
+
+        nquads = jsonld.to_rdf(input, options={'format': 'application/n-quads'})
+
+        assert (
+            '<http://example.com/some/deep/directory/and/file/relativePropertyIris> '
+            '<http://example.com/vocabulary/./rel2#link> '
+            '"link"^^<http://www.w3.org/2001/XMLSchema#string>  .'
+        ) in nquads
+        assert '##fragment-works' not in nquads
+
     def test_large_integer_to_rdf_double_conversion_processing_mode(self):
         """
         In json-ld-1.1 processing mode, large integers should be emitted as xsd:double,


### PR DESCRIPTION
RDF IRI validation in so IRIs with multiple # fragments are skipped during toRDF. 

Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).