### PR TITLE
drop explicitly ignored @id: None subjects when creating node map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Invalid IRI base values within lists are now skipped when serializing to RDF. Fixes [toRdf#tli12](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli12) and [toRdf#tli14](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli14).
 - Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
 - IRI validation now detects multiple # fragments so these IRI's are skipped during toRDF. Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).
+- In `_create_node_map()`, ignored `@id: None` subjects are now dropped before they enter the node map to prevent `_graph_to_rdf()` from crashing when sorting mixed `None` and string keys. Fixes [toRdf#te122](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/lib/pyld/jsonld.py
+++ b/lib/pyld/jsonld.py
@@ -4241,6 +4241,10 @@ class JsonLdProcessor:
         id_ = input_.get('@id')
         if _is_bnode(input_):
             id_ = issuer.get_id(id_)
+        # drop explicitly ignored @id: None subjects before they enter the node map,
+        # while leaving normal blank nodes without @id alone.
+        elif id_ is None and '@id' in input_:
+            return
 
         # create new subject or merge into existing one
         node = graph_map.setdefault(active_graph, {}).setdefault(id_, {'@id': id_})

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1016,7 +1016,6 @@ TEST_TYPES = {
             'idRegex': [
                 # blank node property
                 '.*toRdf-manifest#te075$',
-                '.*toRdf-manifest#te122$',
             ]
         },
         'skip': {


### PR DESCRIPTION
This PR drops ignored `@id: None` subjects in `_create_node_map()`before they enter the node map to prevent `_graph_to_rdf()` from crashing when sorting mixed `None` and string keys. Fixes [toRdf#te122](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122).