### PR TITLE
Add helper to compare generalized nquads in test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Literals with invalid `@language` no longer output triples. Fixes [toRdf#twf05](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05).
 - IRI validation now detects multiple # fragments so these IRI's are skipped during toRDF. Fixes [toRdf#te111](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111) and [toRdf#te112](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112).
 - In `_create_node_map()`, ignored `@id: None` subjects are now dropped before they enter the node map to prevent `_graph_to_rdf()` from crashing when sorting mixed `None` and string keys. Fixes [toRdf#te122](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122).
+- Use a helper for generalized N-Quads normalization in the test runner, since rdflib cannot parse blank-node predicates. Fixes [toRdf#te075](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075).
 
 ### Changed
 - **BREAKING**: Migrated `jsonld.to_rdf()`, `jsonld.from_rdf()`, and N-Quads parsing/serialization to use `rdflib.Dataset` and RDFLib terms directly.

--- a/lib/pyld/options.py
+++ b/lib/pyld/options.py
@@ -146,8 +146,8 @@ class NormalizeOptions(ProcessingOptions, total=False):
     processingMode: Literal['json-ld-1.0', 'json-ld-1.1']
     """Either `json-ld-1.0` or `json-ld-1.1` (default: `json-ld-1.1`)."""
 
-    algorithm: Literal['URDNA2015', 'URGNA2012']
-    """The algorithm to use (default: `URGNA2012`)."""
+    algorithm: Literal['URDNA2015', 'URGNA2012', 'RDFC10']
+    """The algorithm to use (default: `RDFC10`)."""
 
     inputFormat: Literal['application/n-quads']
     """The format if input is not JSON-LD: `application/n-quads` for N-Quads."""

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -455,23 +455,29 @@ class Test(unittest.TestCase):
             if self.is_syntax and not self.pending:
                 self.assertTrue(True)
             elif self.test_type == 'jld:ToRDFTest':
-                # Test normalized results
-                result = jsonld.normalize(
-                    result,
-                    {
-                        'algorithm': 'URGNA2012',
-                        'inputFormat': 'application/n-quads',
-                        'format': 'application/n-quads',
-                    },
-                )
-                expect = jsonld.normalize(
-                    expect,
-                    {
-                        'algorithm': 'URGNA2012',
-                        'inputFormat': 'application/n-quads',
-                        'format': 'application/n-quads',
-                    },
-                )
+                # avoid normalization when produceGeneralizedRdf is enabled,
+                # since the rdflib parser cannot parse blank-node predicates.
+                if data.get('option', {}).get('produceGeneralizedRdf'):
+                    result = _normalize_generalized_nquads_text(result)
+                    expect = _normalize_generalized_nquads_text(expect)
+                else:
+                    # Test normalized results
+                    result = jsonld.normalize(
+                        result,
+                        {
+                            'algorithm': 'RDFC10',
+                            'inputFormat': 'application/n-quads',
+                            'format': 'application/n-quads',
+                        },
+                    )
+                    expect = jsonld.normalize(
+                        expect,
+                        {
+                            'algorithm': 'RDFC10',
+                            'inputFormat': 'application/n-quads',
+                            'format': 'application/n-quads',
+                        },
+                    )
                 if _running_under_pytest():
                     assert result == expect
                 else:
@@ -533,6 +539,26 @@ def assert_results_equal(result, expect, json_output=False):
 
 def _running_under_pytest():
     return 'pytest' in sys.modules
+
+
+def _normalize_generalized_nquads_text(nquads):
+    """Normalize generalized N-Quads text for test-suite comparisons."""
+    # Remove string datatype
+    nquads = nquads.replace(
+        '^^<http://www.w3.org/2001/XMLSchema#string>  .',
+        '.',
+    )
+
+    # Re-label blank nodes
+    bnodes = {}
+
+    # Generalized N-Quads expected results only need deterministic comparison,
+    # not preservation of input blank node labels.
+    nquads = re.sub(r'_:([A-Za-z][A-Za-z0-9]*)', lambda m: bnodes.setdefault(m[0], f'_:b{len(bnodes)}'), nquads)
+    lines = (re.sub(r'\s*\.$', '.', line.strip()) for line in nquads.splitlines())
+
+    # Sort nquads
+    return '\n'.join(sorted(line for line in lines if line))
 
 
 # Compare values with order-insensitive array tests
@@ -925,7 +951,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'compact',
         'params': [
@@ -957,7 +982,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'expand',
         'params': [read_test_url('input'), create_test_options()],
@@ -968,7 +992,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'flatten',
         'params': [
@@ -983,7 +1006,6 @@ TEST_TYPES = {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'frame',
         'params': [
@@ -995,7 +1017,6 @@ TEST_TYPES = {
     'jld:FromRDFTest': {
         'skip': {
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'from_rdf',
         'params': [
@@ -1012,17 +1033,11 @@ TEST_TYPES = {
         ],
     },
     'jld:ToRDFTest': {
-        'pending': {
-            'idRegex': [
-                # blank node property
-                '.*toRdf-manifest#te075$',
-            ]
-        },
+        'pending': {},
         'skip': {
             # skip tests where behavior changed for a 1.1 processor
             # see JSON-LD 1.0 Errata
             'specVersion': ['json-ld-1.0'],
-            'idRegex': [],
         },
         'fn': 'to_rdf',
         'params': [
@@ -1031,8 +1046,8 @@ TEST_TYPES = {
         ],
     },
     'rdfn:Urgna2012EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1046,8 +1061,8 @@ TEST_TYPES = {
         ],
     },
     'rdfn:Urdna2015EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1061,8 +1076,8 @@ TEST_TYPES = {
         ],
     },
     'rdfc:RDFC10EvalTest': {
-        'pending': {'idRegex': []},
-        'skip': {'idRegex': []},
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),
@@ -1074,12 +1089,8 @@ TEST_TYPES = {
         ]
     },
     'rdfc:RDFC10MapTest': {
-        'pending': {
-            'idRegex': []
-        },
-        'skip': {
-            'idRegex': []
-        },
+        'pending': {},
+        'skip': {},
         'fn': 'normalize',
         'params': [
             read_test_property('action'),


### PR DESCRIPTION
Adds a helper for generalized N-Quads normalization in the test runner, since rdflib cannot parse blank-node predicates. Fixes [toRdf#te075](https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075).